### PR TITLE
FIX: `injectManifest` *shenaniganery.

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -12,6 +12,9 @@ const PWA_OPTIONS: Partial<VitePWAOptions> = {
     type: "module",
     enabled: true,
   },
+  injectManifest: {
+    injectionPoint: undefined
+  },
   manifest: {
     // TODO: Add manifest details in a WebManifest.
   },


### PR DESCRIPTION
Fixes #13.

The error message doesn't help that much.

I believe what that the build script assumed we were precaching using Workbox (which we are currently not), which is supposed to replace `self.__WB_MANIFEST`, with the applicable config.

See more [here](https://vite-pwa-org.netlify.app/guide/inject-manifest.html).

So, I have disabled this feature in the `vite.config.ts`, and have managed to successfully `yarn build` now.