### PR TITLE
Profile photo component that takes URL

### DIFF
--- a/packages/frontend/src/components/profile.tsx
+++ b/packages/frontend/src/components/profile.tsx
@@ -1,0 +1,11 @@
+interface ProfPic {
+  imgSrc: string;
+}
+
+export function Profile({ imgSrc }: ProfPic) {
+  return (
+    <div className={`w-[102px] h-[107px] rounded-2xl overflow-hidden`}>
+      <img src={imgSrc} className={`w-full h-full object-cover`} />
+    </div>
+  );
+}


### PR DESCRIPTION
Assuming that tailwind already changes it to base64. To test run:

<div>
        <Profile imgSrc="https://trello.com/1/cards/65d51a05435c78cb5cb4eacf/attachments/65d51a18f3adf7a593ce5788/previews/65d51a19f3adf7a593ce58b7/download/image.png" />{" "}
</div>