### PR TITLE
Add compatibility for running backend on windows

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "tsoa spec-and-routes && tsc",
-    "dev": "(run mongo:stop || true) && run mongo:start && DB_NAME=esp DB_CONN_STRING=mongodb://localhost:27017 run dev:tsoa",
+    "dev": "(run mongo:stop || true) && run mongo:start && cross-env DB_NAME=esp DB_CONN_STRING=mongodb://localhost:27017 run dev:tsoa",
     "dev:tsoa": "tsoa spec-and-routes && concurrently \"nodemon\" \"nodemon -x tsoa spec-and-routes\"",
     "coverage": "jest --coverage",
     "format": "prettier --write 'src/**/*.ts' 'tests/**/*.ts' '*.json'",
@@ -46,6 +46,7 @@
     "@types/supertest": "^6.0.2",
     "@types/swagger-ui-express": "^4.1.6",
     "concurrently": "^8.2.2",
+    "cross-env": "^7.0.3",
     "eslint": "^8.56.0",
     "jest": "^29.7.0",
     "nodemon": "^3.0.1",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -13,8 +13,9 @@
     "gen": "tsoa routes",
     "lint": "eslint src tests --ext ts,tsx --report-unused-disable-directives",
     "lint:fix": "eslint src tests --ext ts,tsx --report-unused-disable-directives --fix",
-    "mongo:start": "mkdir -p mongo_data && docker run -d --rm -p 127.0.0.1:27017:27017 --name esp-mongo-test -v ./mongo_data:/data/db -v ./etc/mongod.conf:/etc/mongod.conf mongo:latest --config /etc/mongod.conf",
-    "mongo:stop": "docker stop $(docker ps -a --filter name=esp-mongo-test --format='{{.ID}}')",
+    "mongo:setup": "docker volume create esp_mongo_data",
+    "mongo:start": "cross-env-shell docker run -d --rm -p '127.0.0.1:27017:27017' --name esp-mongo-test -v esp_mongo_data:/data/db --mount '\"type=bind,source=$INIT_CWD/etc/mongod.conf,target=/etc/mongod.conf\"' mongo:latest --config '/etc/mongod.conf'",
+    "mongo:stop": "docker stop esp-mongo-test",
     "start": "node build/src/server.js",
     "test": "jest"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -1824,6 +1824,7 @@ __metadata:
     access-token-jwt: "https://github.com/ESP-Number-One/access-token-jwt"
     concurrently: "npm:^8.2.2"
     cors: "npm:^2.8.5"
+    cross-env: "npm:^7.0.3"
     eslint: "npm:^8.56.0"
     express: "npm:^4.18.2"
     jest: "npm:^29.7.0"
@@ -4784,6 +4785,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cross-env@npm:^7.0.3":
+  version: 7.0.3
+  resolution: "cross-env@npm:7.0.3"
+  dependencies:
+    cross-spawn: "npm:^7.0.1"
+  bin:
+    cross-env: src/bin/cross-env.js
+    cross-env-shell: src/bin/cross-env-shell.js
+  checksum: f3765c25746c69fcca369655c442c6c886e54ccf3ab8c16847d5ad0e91e2f337d36eedc6599c1227904bf2a228d721e690324446876115bc8e7b32a866735ecf
+  languageName: node
+  linkType: hard
+
 "cross-fetch@npm:^3.0.4":
   version: 3.1.8
   resolution: "cross-fetch@npm:3.1.8"
@@ -4793,7 +4806,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
+"cross-spawn@npm:^7.0.0, cross-spawn@npm:^7.0.1, cross-spawn@npm:^7.0.2, cross-spawn@npm:^7.0.3":
   version: 7.0.3
   resolution: "cross-spawn@npm:7.0.3"
   dependencies:


### PR DESCRIPTION
### Summary

Windows sucks (more than I actually thought)

But this gets it `yarn dev` working on windows. However you may have to run `yarn mongo:setup` beforehand? Idk

It also removes the need for `mongo_data` in the repository (yay :tada:)

### Testing

Successfully ran `yarn dev` in a Windows VM