### PR TITLE
Add missing endpoints to API client

### DIFF
--- a/packages/api-client/src/sub/base.ts
+++ b/packages/api-client/src/sub/base.ts
@@ -1,4 +1,4 @@
-import type { ObjectId, QueryOptions } from "@esp-group-one/types";
+import type { ObjectId, PageOptions, SortQuery } from "@esp-group-one/types";
 import { APIClientBase } from "../base.js";
 
 export class SubAPIClient<
@@ -27,7 +27,9 @@ export class SubAPIClient<
   /**
    * @returns all users found matching the query
    */
-  public find(query: QueryOptions<Query>): Promise<Censored[]> {
+  public find(
+    query: PageOptions<Query, SortQuery<FullType>>,
+  ): Promise<Censored[]> {
     return this.post("find", query);
   }
 }

--- a/packages/api-client/src/sub/league.ts
+++ b/packages/api-client/src/sub/league.ts
@@ -3,6 +3,7 @@ import type {
   League,
   LeagueCreation,
   LeagueQuery,
+  ObjectId,
 } from "@esp-group-one/types";
 import { SubAPIClient } from "./base.js";
 
@@ -11,4 +12,31 @@ export class LeagueAPIClient extends SubAPIClient<
   CensoredLeague,
   LeagueCreation,
   LeagueQuery
-> {}
+> {
+  /**
+   * @param id - The id of the league to edit
+   * @param details - An object containing the information you want to edit
+   *   about the user
+   * @returns void
+   */
+  public edit(id: ObjectId, details: Partial<LeagueCreation>): Promise<void> {
+    return this.post(`${id.toString()}/edit`, details);
+  }
+
+  /**
+   * @param id - The id of the private league to get the invite code for
+   * @returns the invite code if the current user is the owner
+   */
+  public getInviteCode(id: ObjectId): Promise<string> {
+    return this.get(`${id.toString()}/invite`, {});
+  }
+
+  /**
+   * @param id - The id of the league to join
+   * @param inviteCode - If the league is private, an invite code is required
+   * @returns void
+   */
+  public join(id: ObjectId, inviteCode?: string): Promise<void> {
+    return this.post(`${id.toString()}/join`, { inviteCode });
+  }
+}

--- a/packages/api-client/src/sub/user.ts
+++ b/packages/api-client/src/sub/user.ts
@@ -24,6 +24,15 @@ export class UserAPIClient extends SubAPIClient<
   }
 
   /**
+   * @param details - An object containing the information you want to edit
+   *   about the user
+   * @returns void
+   */
+  public editMe(details: Partial<UserCreation>): Promise<void> {
+    return this.post("me/edit", details);
+  }
+
+  /**
    * @param id - ID of the user to get
    * @returns webp base64 encoded image with prefix `data:image/webp;base64,` so can be assigned to img.src
    */

--- a/packages/api-client/tests/sub/league.test.ts
+++ b/packages/api-client/tests/sub/league.test.ts
@@ -1,0 +1,74 @@
+import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
+import { newAPISuccess, Sport } from "@esp-group-one/types";
+import { IDS, OIDS } from "@esp-group-one/test-helpers";
+import { fetchMockEndpointOnce, runErrorTests } from "../helpers/utils.js";
+import { APIClient } from "../../src/client.js";
+import type { LeagueAPIClient } from "../../src/sub/league.js";
+import { fetchMock } from "../helpers/fetch_mock.js";
+
+fetchMock.enableMocks();
+beforeEach(() => {
+  fetchMock.resetMocks();
+});
+
+let api: LeagueAPIClient;
+beforeAll(() => {
+  api = new APIClient("gimmeaccess").league();
+});
+
+describe("edit", () => {
+  const id = OIDS[0];
+  const endpoint = `league/${IDS[0]}/edit`;
+
+  test("Normal", async () => {
+    const body = { name: "Test league 10000" };
+
+    fetchMockEndpointOnce(endpoint, newAPISuccess(undefined), { body });
+
+    await expect(api.edit(id, body)).resolves.toBe(undefined);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  runErrorTests(endpoint, () => api.edit(id, { sport: Sport.Squash }));
+});
+
+describe("join", () => {
+  const id = OIDS[0];
+  const endpoint = `league/${IDS[0]}/join`;
+
+  test("with inviteCode", async () => {
+    const inviteCode = "HI";
+
+    fetchMockEndpointOnce(endpoint, newAPISuccess(undefined), {
+      body: { inviteCode },
+    });
+
+    await expect(api.join(id, inviteCode)).resolves.toBe(undefined);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test("without inviteCode", async () => {
+    fetchMockEndpointOnce(endpoint, newAPISuccess(undefined), {
+      body: {},
+    });
+
+    await expect(api.join(id)).resolves.toBe(undefined);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  runErrorTests(endpoint, () => api.join(id));
+});
+
+describe("getInviteCode", () => {
+  const id = OIDS[0];
+  const endpoint = `league/${IDS[0]}/invite`;
+
+  test("normal", async () => {
+    fetchMockEndpointOnce(endpoint, newAPISuccess(undefined), { query: {} });
+
+    await expect(api.getInviteCode(id)).resolves.toBe(undefined);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  runErrorTests(endpoint, () => api.getInviteCode(id));
+});

--- a/packages/api-client/tests/sub/user.test.ts
+++ b/packages/api-client/tests/sub/user.test.ts
@@ -35,6 +35,21 @@ describe("addAvailability", () => {
   runErrorTests(endpoint, () => api.addAvailability(availability));
 });
 
+describe("edit", () => {
+  const endpoint = "user/me/edit";
+
+  test("Normal", async () => {
+    const body = { name: "Test bot 10000" };
+
+    fetchMockEndpointOnce(endpoint, newAPISuccess(undefined), { body });
+
+    await expect(api.editMe(body)).resolves.toBe(undefined);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  runErrorTests(endpoint, () => api.editMe({ description: "Something" }));
+});
+
 describe("getProfilePic", () => {
   const id = OIDS[0];
   const resObj = "data:image/webp;base64,AAAAAAAA";


### PR DESCRIPTION
Works towards things mentioned in #63 

- Adds the missing endpoints to the API client
- Fixes use of `QueryOptions` instead of `PageOptions`