### PR TITLE
Add ability to rate a user after a match

### DIFF
--- a/packages/backend/src/user/user_controller.ts
+++ b/packages/backend/src/user/user_controller.ts
@@ -177,6 +177,7 @@ export class UsersController extends ControllerWrap<User> {
             sports: [],
             leagues: [],
             availability: [],
+            rating: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
             ...userCreation,
           }).then(async (user) => {
             // Error should be passed up to the next catch

--- a/packages/backend/tests/controllers/user.test.ts
+++ b/packages/backend/tests/controllers/user.test.ts
@@ -242,6 +242,7 @@ addCommonTests({
         description: "bla bla bla",
         profilePicture: "",
         email: "new@test.com",
+        rating: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 },
         sports: [],
         leagues: [],
         availability: [],

--- a/packages/types/src/match.ts
+++ b/packages/types/src/match.ts
@@ -36,6 +36,7 @@ interface MatchWithScore extends BaseMatch {
   // Maps player id to score
   score: Scores;
   status: MatchStatus.Complete;
+  usersRated: ObjectId[];
 }
 
 interface LeagueInfo {

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -7,6 +7,9 @@ export enum AbilityLevel {
   Advanced = "advanced",
 }
 
+export type StarCount = 1 | 2 | 3 | 4 | 5;
+export type Ratings = Record<StarCount, number>;
+
 export interface SportInfo {
   sport: Sport;
   ability: string;
@@ -38,12 +41,14 @@ export interface User extends MongoDBItem {
   sports: SportInfo[];
   leagues: ObjectId[];
   availability: Availability[];
+  rating: Ratings;
 }
 
 export interface CensoredUser extends MongoDBItem {
   name: string;
   description: string;
   sports: SportInfo[];
+  rating: Ratings;
 }
 
 export function censorUser(user: User): CensoredUser {
@@ -52,6 +57,7 @@ export function censorUser(user: User): CensoredUser {
     name: user.name,
     description: user.description,
     sports: user.sports,
+    rating: user.rating,
   };
 }
 
@@ -66,3 +72,12 @@ export type UserQuery = Query<{
   sports: string[];
   leagues: ObjectId[];
 }> & { profileText?: string };
+
+export function calculateAverageRating(rate: Ratings): number {
+  const count = Object.values(rate).reduce((a, b) => a + b, 0);
+  const sum = Object.entries(rate)
+    .map(([stars, ratings]) => Number(stars) * ratings)
+    .reduce((a, b) => a + b, 0);
+
+  return sum / count;
+}

--- a/packages/types/tests/user.test.ts
+++ b/packages/types/tests/user.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@jest/globals";
-import { censorUser } from "../src/user.js";
+import type { Ratings } from "../src/user.js";
+import { calculateAverageRating, censorUser } from "../src/user.js";
 import { ObjectId, Sport } from "../src/utils.js";
 import { getUser, IDS } from "./utils.js";
 
@@ -9,9 +10,32 @@ test("user", () => {
     _id: new ObjectId(IDS[0]),
     name: "Test bot",
     description: "Tester9000",
+    rating: { 1: 5, 2: 10, 3: 20, 4: 50, 5: 10 },
     sports: [
       { sport: Sport.Tennis, ability: "beginner" },
       { sport: Sport.Squash, ability: "expert" },
     ],
+  });
+});
+
+describe("calculateAverageRating", () => {
+  test("All same", () => {
+    const rate: Ratings = { 1: 0, 2: 0, 3: 200, 4: 0, 5: 0 };
+    expect(calculateAverageRating(rate)).toBe(3);
+  });
+
+  test("All one", () => {
+    const rate: Ratings = { 1: 1, 2: 1, 3: 1, 4: 1, 5: 1 };
+    expect(calculateAverageRating(rate)).toBe(3);
+  });
+
+  test("with zeros", () => {
+    const rate: Ratings = { 1: 2, 2: 0, 3: 1, 4: 0, 5: 2 };
+    expect(calculateAverageRating(rate)).toBe(3);
+  });
+
+  test("float output", () => {
+    const rate: Ratings = { 1: 0, 2: 0, 3: 0, 4: 2, 5: 2 };
+    expect(calculateAverageRating(rate)).toBe(4.5);
   });
 });

--- a/packages/types/tests/utils.ts
+++ b/packages/types/tests/utils.ts
@@ -87,6 +87,7 @@ export function getUser(obj: Partial<User>): User {
         timeEnd: new Date().toLocaleString(),
       },
     ],
+    rating: obj.rating ?? { 1: 5, 2: 10, 3: 20, 4: 50, 5: 10 },
   };
 }
 

--- a/packages/types/tests/utils.ts
+++ b/packages/types/tests/utils.ts
@@ -52,6 +52,7 @@ export function getMatch(obj: Partial<Match>): Match {
     match = {
       ...base,
       status: MatchStatus.Complete,
+      usersRated: obj.usersRated ?? [],
       score,
     };
   } else {


### PR DESCRIPTION
### Summary

Allows a user to rate another once they have completed a match together

- A user can only rate another user 1 per match
- Stores ratings as a number for each of the possible stars (1, 2, 3, 4, 5) which the frontend can then workout the average.

### TODO

- [x] Add testing for the rating endpoint
- [x] Update existing tests to include the new ratings object

### Testing

Unit tests have been added