### PR TITLE
Move each page to be in control of the footer + header

### DIFF
--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -1,10 +1,6 @@
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faPlus } from "@fortawesome/free-solid-svg-icons";
-import { Route, Routes, type To, useNavigate } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
 import { useEffect, useRef, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
-import { Page } from "./components/page/index.js";
-import { Header } from "./components/page/header.js";
 import { TestPage } from "./pages/test.js";
 import { AnotherTestPage } from "./pages/another_test.js";
 import { API, type AuthResult, handleApi } from "./state/auth.js";
@@ -15,21 +11,6 @@ export function App() {
   const [result, setResult] = useState({ type: "loading" } as AuthResult);
   const hasSetApi = useRef(false);
   const { isAuthenticated } = useAuth0();
-  const navigate = useNavigate();
-  const viewNavigate = (newRoute: To) => {
-    // Navigate to the new route
-    if (
-      !(document as unknown as { startViewTransition?: unknown })
-        .startViewTransition
-    ) {
-      navigate(newRoute);
-    } else {
-      return document.startViewTransition(() => {
-        navigate(newRoute);
-      });
-    }
-  };
-
   const api = useAPIClient(isAuthenticated);
 
   useEffect(() => {
@@ -54,37 +35,10 @@ export function App() {
 
   return ok.authenticated ? (
     <API.Provider value={ok.client}>
-      <Page>
-        <Page.Header>
-          <Header.Back />
-          Whatever goes in here, stays in here.
-          <Header.Right>
-            <FontAwesomeIcon icon={faPlus} />
-          </Header.Right>
-        </Page.Header>
-        <Page.Body style={{ viewTransitionName: "body-content" }}>
-          <Routes>
-            <Route index element={<TestPage />} />
-            <Route path="/another" element={<AnotherTestPage />} />
-          </Routes>
-        </Page.Body>
-        <Page.Footer>
-          <button
-            onClick={() => {
-              viewNavigate("/");
-            }}
-          >
-            First Test page
-          </button>
-          <button
-            onClick={() => {
-              viewNavigate("/another");
-            }}
-          >
-            Another page.
-          </button>
-        </Page.Footer>
-      </Page>
+      <Routes>
+        <Route index element={<TestPage />} />
+        <Route path="/another" element={<AnotherTestPage />} />
+      </Routes>
     </API.Provider>
   ) : (
     <div className="flex min-h-screen px-3 items-center place-content-center">

--- a/packages/frontend/src/components/page/index.tsx
+++ b/packages/frontend/src/components/page/index.tsx
@@ -43,9 +43,12 @@ interface BodyProps {
 
 PageImpl.Header = Header;
 
-PageImpl.Body = function Body({ children, className, style }: BodyProps) {
+PageImpl.Body = function Body({ children, className }: BodyProps) {
   return (
-    <div className={`h-full ${className}`} style={style}>
+    <div
+      className={`h-full ${className}`}
+      style={{ viewTransitionName: "body-content" }}
+    >
       {children}
     </div>
   );

--- a/packages/frontend/src/components/page/index.tsx
+++ b/packages/frontend/src/components/page/index.tsx
@@ -21,13 +21,13 @@ function PageImpl({
   return (
     <div className="root-page flex h-screen w-screen flex-col">
       {header !== undefined ? (
-        <div className="w-full p-5 bg-slate-500 text-white font-title text-2xl font-bold">
+        <div className="flex-none w-full p-5 bg-slate-500 text-white font-title text-2xl font-bold">
           <div className="relative flex w-full">{header}</div>
         </div>
       ) : null}
-      <div className="h-full">{body}</div>
+      <div className="flex-1 min-h-0 h-full px-2">{body}</div>
       {footer !== undefined ? (
-        <div className="w-full p-5 bg-slate-400 text-white font-title justify-end">
+        <div className="flex-none w-full p-5 bg-slate-400 text-white font-title justify-end">
           {footer}
         </div>
       ) : null}
@@ -35,16 +35,20 @@ function PageImpl({
   );
 }
 
+interface BodyProps {
+  children: ReactNode;
+  className?: string;
+  style?: CSSProperties;
+}
+
 PageImpl.Header = Header;
 
-PageImpl.Body = function Body({
-  children,
-  style,
-}: {
-  children: ReactNode;
-  style?: CSSProperties;
-}) {
-  return <div style={style}>{children}</div>;
+PageImpl.Body = function Body({ children, className, style }: BodyProps) {
+  return (
+    <div className={`h-full ${className}`} style={style}>
+      {children}
+    </div>
+  );
 };
 
 PageImpl.Footer = function Footer({ children }: { children: ReactNode }) {
@@ -54,7 +58,7 @@ PageImpl.Footer = function Footer({ children }: { children: ReactNode }) {
 interface PageT {
   (_: { children: ReactNode }): JSX.Element;
   Header: (_: { children: ReactNode }) => JSX.Element;
-  Body: (_: { children: ReactNode; style?: CSSProperties }) => JSX.Element;
+  Body: (_: BodyProps) => JSX.Element;
   Footer: (_: { children: ReactNode }) => JSX.Element;
 }
 

--- a/packages/frontend/src/pages/another_test.tsx
+++ b/packages/frontend/src/pages/another_test.tsx
@@ -25,7 +25,7 @@ export function AnotherTestPage() {
           <FontAwesomeIcon icon={faPlus} />
         </Header.Right>
       </Page.Header>
-      <Page.Body style={{ viewTransitionName: "body-content" }}>
+      <Page.Body>
         {user !== undefined ? (
           <div className=" bg-red-700">{JSON.stringify(user)}</div>
         ) : (

--- a/packages/frontend/src/pages/another_test.tsx
+++ b/packages/frontend/src/pages/another_test.tsx
@@ -1,18 +1,53 @@
 import { useContext, useEffect, useState } from "react";
 import { type User } from "@esp-group-one/types";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { API } from "../state/auth";
+import { Page } from "../components/page";
+import { Header } from "../components/page/header";
+import { useViewNav } from "../state/nav";
 
 export function AnotherTestPage() {
   const api = useContext(API);
   const [user, setUser] = useState(undefined as undefined | User);
+  const viewNavigate = useViewNav();
 
   useEffect(() => {
     api.user().me().then(setUser).catch(console.warn);
   }, [api]);
 
-  return user !== undefined ? (
-    <div className=" bg-red-700">{JSON.stringify(user)}</div>
-  ) : (
-    <p>Loading</p>
+  return (
+    <Page>
+      <Page.Header>
+        <Header.Back />
+        Whatever goes in here, stays in here.
+        <Header.Right>
+          <FontAwesomeIcon icon={faPlus} />
+        </Header.Right>
+      </Page.Header>
+      <Page.Body style={{ viewTransitionName: "body-content" }}>
+        {user !== undefined ? (
+          <div className=" bg-red-700">{JSON.stringify(user)}</div>
+        ) : (
+          <p>Loading</p>
+        )}
+      </Page.Body>
+      <Page.Footer>
+        <button
+          onClick={() => {
+            viewNavigate("/");
+          }}
+        >
+          First Test page
+        </button>
+        <button
+          onClick={() => {
+            viewNavigate("/another");
+          }}
+        >
+          Another page.
+        </button>
+      </Page.Footer>
+    </Page>
   );
 }

--- a/packages/frontend/src/pages/test.tsx
+++ b/packages/frontend/src/pages/test.tsx
@@ -1,12 +1,44 @@
 import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus } from "@fortawesome/free-solid-svg-icons";
 import { Stars } from "../components/stars";
+import { Page } from "../components/page";
+import { Header } from "../components/page/header";
+import { useViewNav } from "../state/nav";
 
 export function TestPage() {
   const [rating, setRating] = useState(2);
+  const viewNavigate = useViewNav();
+
   return (
-    <>
-      <p className=" bg-progress-blue">First page!</p>
-      <Stars rating={rating} onRatingChange={setRating} />
-    </>
+    <Page>
+      <Page.Header>
+        <Header.Back />
+        Whatever goes in here, stays in here.
+        <Header.Right>
+          <FontAwesomeIcon icon={faPlus} />
+        </Header.Right>
+      </Page.Header>
+      <Page.Body style={{ viewTransitionName: "body-content" }}>
+        <p className=" bg-progress-blue">First page!</p>
+        <Stars rating={rating} onRatingChange={setRating} />
+      </Page.Body>
+      <Page.Footer>
+        <button
+          onClick={() => {
+            viewNavigate("/");
+          }}
+        >
+          First Test page
+        </button>
+        <button
+          onClick={() => {
+            viewNavigate("/another");
+          }}
+        >
+          Another page.
+        </button>
+      </Page.Footer>
+    </Page>
   );
 }

--- a/packages/frontend/src/pages/test.tsx
+++ b/packages/frontend/src/pages/test.tsx
@@ -19,7 +19,7 @@ export function TestPage() {
           <FontAwesomeIcon icon={faPlus} />
         </Header.Right>
       </Page.Header>
-      <Page.Body style={{ viewTransitionName: "body-content" }}>
+      <Page.Body>
         <p className=" bg-progress-blue">First page!</p>
         <Stars rating={rating} onRatingChange={setRating} />
       </Page.Body>

--- a/packages/frontend/src/state/nav.ts
+++ b/packages/frontend/src/state/nav.ts
@@ -1,0 +1,19 @@
+import type { To } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
+
+export function useViewNav() {
+  const navigate = useNavigate();
+  return (newRoute: To) => {
+    // Navigate to the new route
+    if (
+      !(document as unknown as { startViewTransition?: unknown })
+        .startViewTransition
+    ) {
+      navigate(newRoute);
+    } else {
+      return document.startViewTransition(() => {
+        navigate(newRoute);
+      });
+    }
+  };
+}


### PR DESCRIPTION
### Summary

When creating pages, we need to have more flexibility of the header + footer.

This moves the pages to specify that and have the `app.tsx` do basic routing.