### PR TITLE
Refactor testing logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "lint-ci": "yarn workspaces foreach -Ap run lint --max-warnings 0",
     "lint:fix": "yarn workspaces foreach -Ap run lint:fix",
     "test": "jest",
+    "test:setup": "yarn workspace @esp-group-one/test-env run setup",
     "test:linux": "act -j test"
   },
   "devDependencies": {

--- a/packages/api-client/package.json
+++ b/packages/api-client/package.json
@@ -19,6 +19,7 @@
   "devDependencies": {
     "@esp-group-one/eslint-config": "workspace:^",
     "@esp-group-one/jest-esm-transformer": "workspace:^",
+    "@esp-group-one/test-helpers": "workspace:^",
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.7",

--- a/packages/api-client/tests/base.test.ts
+++ b/packages/api-client/tests/base.test.ts
@@ -1,15 +1,8 @@
 import { beforeEach, describe, expect, test } from "@jest/globals";
-import fetchMockImp, { type FetchMock } from "jest-fetch-mock";
 import { newAPISuccess } from "@esp-group-one/types";
 import { APIClientBase } from "../src/base.js";
-import { fetchMockEndpointOnce, runErrorTests } from "./lib/utils.js";
-
-// TypeScript is weird and seems to believe the type is two different things
-// depending on running build/test
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- two typescript versions colliding
-const fetchMock: FetchMock = (
-  "default" in fetchMockImp ? fetchMockImp.default : fetchMockImp
-) as FetchMock;
+import { fetchMockEndpointOnce, runErrorTests } from "./helpers/utils.js";
+import { fetchMock } from "./helpers/fetch_mock.js";
 
 fetchMock.enableMocks();
 beforeEach(() => {

--- a/packages/api-client/tests/helpers/fetch_mock.ts
+++ b/packages/api-client/tests/helpers/fetch_mock.ts
@@ -1,0 +1,12 @@
+// TypeScript is weird and seems to believe the type is two different things
+// depending on running build/test
+
+import type { FetchMock } from "jest-fetch-mock";
+import fetchMockImp from "jest-fetch-mock";
+
+// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- two typescript versions colliding
+const fetchMock: FetchMock = (
+  "default" in fetchMockImp ? fetchMockImp.default : fetchMockImp
+) as FetchMock;
+
+export { fetchMock, type FetchMock };

--- a/packages/api-client/tests/helpers/utils.ts
+++ b/packages/api-client/tests/helpers/utils.ts
@@ -1,13 +1,6 @@
 import { expect, test } from "@jest/globals";
-import fetchMockImp, { type FetchMock } from "jest-fetch-mock";
 import { newAPIError } from "@esp-group-one/types";
-
-// TypeScript is weird and seems to believe the type is two different things
-// depending on running build/test
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- two typescript versions colliding
-const fetchMock: FetchMock = (
-  "default" in fetchMockImp ? fetchMockImp.default : fetchMockImp
-) as FetchMock;
+import { fetchMock } from "./fetch_mock.js";
 
 export function fetchMockEndpointOnce<T, R>(
   endpoint: string,

--- a/packages/api-client/tests/sub/base.test.ts
+++ b/packages/api-client/tests/sub/base.test.ts
@@ -1,18 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
-import fetchMockImp, { type FetchMock } from "jest-fetch-mock";
 import type { Query } from "@esp-group-one/types";
-import { newAPISuccess, ObjectId, tests } from "@esp-group-one/types";
+import { newAPISuccess, ObjectId } from "@esp-group-one/types";
+import { IDS } from "@esp-group-one/test-helpers";
 import { SubAPIClient } from "../../src/sub/base.js";
-import { fetchMockEndpointOnce, runErrorTests } from "../lib/utils.js";
-
-const { IDS } = tests;
-
-// TypeScript is weird and seems to believe the type is two different things
-// depending on running build/test
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- two typescript versions colliding
-const fetchMock: FetchMock = (
-  "default" in fetchMockImp ? fetchMockImp.default : fetchMockImp
-) as FetchMock;
+import { fetchMockEndpointOnce, runErrorTests } from "../helpers/utils.js";
+import { fetchMock } from "../helpers/fetch_mock.js";
 
 fetchMock.enableMocks();
 beforeEach(() => {

--- a/packages/api-client/tests/sub/match.test.ts
+++ b/packages/api-client/tests/sub/match.test.ts
@@ -1,19 +1,11 @@
 import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
-import fetchMockImp, { type FetchMock } from "jest-fetch-mock";
 import type { Scores } from "@esp-group-one/types";
-import { newAPISuccess, ObjectId, Sport, tests } from "@esp-group-one/types";
-import { fetchMockEndpointOnce, runErrorTests } from "../lib/utils.js";
+import { newAPISuccess, ObjectId, Sport } from "@esp-group-one/types";
+import { getMatch, IDS } from "@esp-group-one/test-helpers";
+import { fetchMockEndpointOnce, runErrorTests } from "../helpers/utils.js";
 import { APIClient } from "../../src/client.js";
 import type { MatchAPIClient } from "../../src/sub/match.js";
-
-const { getMatch, IDS } = tests;
-
-// TypeScript is weird and seems to believe the type is two different things
-// depending on running build/test
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- two typescript versions colliding
-const fetchMock: FetchMock = (
-  "default" in fetchMockImp ? fetchMockImp.default : fetchMockImp
-) as FetchMock;
+import { fetchMock } from "../helpers/fetch_mock.js";
 
 fetchMock.enableMocks();
 beforeEach(() => {

--- a/packages/api-client/tests/sub/user.test.ts
+++ b/packages/api-client/tests/sub/user.test.ts
@@ -1,18 +1,10 @@
 import { beforeAll, beforeEach, describe, expect, test } from "@jest/globals";
-import fetchMockImp, { type FetchMock } from "jest-fetch-mock";
-import { newAPISuccess, ObjectId, tests } from "@esp-group-one/types";
-import { fetchMockEndpointOnce, runErrorTests } from "../lib/utils.js";
+import { newAPISuccess, ObjectId } from "@esp-group-one/types";
+import { getUser, IDS } from "@esp-group-one/test-helpers";
+import { fetchMockEndpointOnce, runErrorTests } from "../helpers/utils.js";
 import type { UserAPIClient } from "../../src/sub/user.js";
 import { APIClient } from "../../src/client.js";
-
-const { getUser, IDS } = tests;
-
-// TypeScript is weird and seems to believe the type is two different things
-// depending on running build/test
-// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion -- two typescript versions colliding
-const fetchMock: FetchMock = (
-  "default" in fetchMockImp ? fetchMockImp.default : fetchMockImp
-) as FetchMock;
+import { fetchMock } from "../helpers/fetch_mock.js";
 
 fetchMock.enableMocks();
 beforeEach(() => {

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -38,6 +38,7 @@
     "@esp-group-one/eslint-config": "workspace:^",
     "@esp-group-one/jest-esm-transformer": "workspace:^",
     "@esp-group-one/mongodb-testing": "workspace:^",
+    "@esp-group-one/test-helpers": "workspace:^",
     "@jest/globals": "^29.7.0",
     "@types/cors": "^2.8.15",
     "@types/express": "^4.17.20",

--- a/packages/backend/src/league/league_controller.ts
+++ b/packages/backend/src/league/league_controller.ts
@@ -7,6 +7,7 @@ import {
   ObjectId,
   PageOptions,
   ID,
+  hasId,
 } from "@esp-group-one/types";
 import type {
   Error,
@@ -82,10 +83,7 @@ export class LeaguesController extends ControllerWrap<League> {
     return this.withUserId(req, async (userId) => {
       const res = await this.get(id);
       if (res.success) {
-        if (
-          res.data.private &&
-          res.data.ownerIds.map((e) => e.toString()).includes(userId.toString())
-        )
+        if (res.data.private && hasId(res.data.ownerIds, userId))
           return newAPISuccess(res.data.inviteCode);
 
         // Don't want to give away the league exists if user does not have
@@ -174,7 +172,7 @@ export class LeaguesController extends ControllerWrap<League> {
   ): Promise<WithError<undefined>> {
     const id = new ObjectId(leagueId);
     return this.withUser(req, async (currUser) => {
-      if (!currUser.leagues.map((e) => e.toString()).includes(id.toString())) {
+      if (!hasId(currUser.leagues, id)) {
         const league = await (await this.getCollection()).get(id);
         if (
           league &&
@@ -252,12 +250,7 @@ export class LeaguesController extends ControllerWrap<League> {
         if (!getRes.success) return getRes;
 
         const league = getRes.data;
-        if (
-          !league.ownerIds
-            .map((e) => e.toString())
-            .includes(currUser.toString())
-        )
-          return this.notFound();
+        if (!hasId(league.ownerIds, currUser)) return this.notFound();
 
         const coll = await this.getCollection();
         const res: Promise<WithError<undefined>> = coll

--- a/packages/backend/src/match/match_controller.ts
+++ b/packages/backend/src/match/match_controller.ts
@@ -8,6 +8,7 @@ import {
   newAPISuccess,
   Scores,
   ID,
+  hasId,
 } from "@esp-group-one/types";
 import type {
   Match,
@@ -53,9 +54,7 @@ export class MatchsController extends ControllerWrap<Match> {
       const res = await this.get(id);
       if (res.success) {
         if (
-          !res.data.players
-            .map((p) => p.toString())
-            .includes(userId.toString()) ||
+          !hasId(res.data.players, userId) ||
           res.data.owner.toString() === userId.toString()
         ) {
           return this.notFound();
@@ -89,9 +88,7 @@ export class MatchsController extends ControllerWrap<Match> {
     return this.withUserId(req, async (userId) => {
       const res = await this.get(id);
       if (res.success) {
-        if (
-          !res.data.players.map((p) => p.toString()).includes(userId.toString())
-        ) {
+        if (!hasId(res.data.players, userId)) {
           return this.notFound();
         }
 
@@ -107,11 +104,10 @@ export class MatchsController extends ControllerWrap<Match> {
 
         /* SCORES VALIDATION */
         const players = Object.keys(scores);
-        const matchPlayers = res.data.players.map((p) => p.toString());
 
         // Get players which aren't in the match
         const difference = players.filter(
-          (x) => !matchPlayers.includes(x.toString()),
+          (x) => !hasId(res.data.players, new ObjectId(x)),
         );
 
         if (
@@ -154,9 +150,7 @@ export class MatchsController extends ControllerWrap<Match> {
     return this.withUserId(req, async (userId) => {
       const res = await this.get(id);
       if (res.success) {
-        if (
-          !res.data.players.map((p) => p.toString()).includes(userId.toString())
-        ) {
+        if (!hasId(res.data.players, userId)) {
           return this.notFound();
         }
 
@@ -170,17 +164,13 @@ export class MatchsController extends ControllerWrap<Match> {
         console.log(
           JSON.stringify(res.data.usersRated.map((p) => p.toString())),
         );
-        if (
-          res.data.usersRated
-            .map((p) => p.toString())
-            .includes(userId.toString())
-        ) {
+        if (hasId(res.data.usersRated, userId)) {
           this.setStatus(400);
           return newAPIError("You have already rated the match!");
         }
 
         const playersBeingRated = res.data.players.filter(
-          (p) => p.toString() !== userId.toString(),
+          (p) => !p.equals(userId),
         );
 
         const users = await this.getDb().users();
@@ -214,9 +204,7 @@ export class MatchsController extends ControllerWrap<Match> {
     return this.withUserId(req, async (userId) => {
       const res = await this.get(id);
       if (res.success) {
-        if (
-          !res.data.players.map((p) => p.toString()).includes(userId.toString())
-        ) {
+        if (!hasId(res.data.players, userId)) {
           return this.notFound();
         }
       }
@@ -315,11 +303,7 @@ export class MatchsController extends ControllerWrap<Match> {
 
         // TODO: Consider removing when we replace with the auto league assignment
         if ("league" in proposal) {
-          if (
-            !user.leagues
-              .map((l) => l.toString())
-              .includes(proposal.league.toString())
-          ) {
+          if (!hasId(user.leagues, proposal.league)) {
             this.setStatus(400);
             return newAPIError("You must be in the league to create a match");
           }

--- a/packages/backend/tests/controllers/league.test.ts
+++ b/packages/backend/tests/controllers/league.test.ts
@@ -1,242 +1,191 @@
-import type { LeagueCreation, User } from "@esp-group-one/types";
-import { ObjectId, Sport, censorLeague, tests } from "@esp-group-one/types";
+import type { LeagueCreation } from "@esp-group-one/types";
+import { ObjectId, Sport, censorLeague } from "@esp-group-one/types";
 import { expect } from "@jest/globals";
 import { generateRandomString } from "ts-randomstring/lib/index.js";
-import { addCommonTests, setup, withDb } from "../helpers/controller.js";
-import {
-  addLeague,
-  addUser,
-  expectAPIRes,
-  requestWithAuth,
-} from "../helpers/utils.js";
+import { IDS, OIDS, addLeague, addUser } from "@esp-group-one/test-helpers";
+import { addCommonTests, setup } from "../helpers/controller.js";
+import { expectAPIRes } from "../helpers/utils.js";
 import { app } from "../../src/app.js";
+import { TestUser } from "../helpers/user.js";
 
-const { IDS } = tests;
-
-setup();
+const db = setup();
+const user = new TestUser(db, "github|111112");
 
 jest.mock("access-token-jwt");
 
 describe("get", () => {
   test("private league", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db, { private: true });
-      const auth0Id = "github|123456";
-      await addUser(db, auth0Id);
+    const league = await addLeague(db.get(), { private: true });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .get(`/league/${league._id.toString()}`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user.request(app).get(`/league/${league._id.toString()}`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 });
 
 describe("find", () => {
-  const auth0Id = "github|123456";
-  let user: User;
-
-  beforeEach(async () => {
-    user = await withDb((db) => addUser(db, auth0Id));
-  });
-
   test("am in", async () => {
-    await withDb(async (db) => {
-      const expected = await addLeague(db, { name: "My league" });
-      await addLeague(db, { name: "not my league" });
-      await (
-        await db.users()
-      ).edit(user._id, { $set: { leagues: [expected._id] } });
+    const expected = await addLeague(db.get(), { name: "My league" });
+    await addLeague(db.get(), { name: "not my league" });
+    await user.edit({ $set: { leagues: [expected._id] } });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/league/find")
-        .send({ query: { amIn: true } })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post("/league/find")
+      .send({ query: { amIn: true } });
 
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [censorLeague(expected)],
-      });
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [censorLeague(expected)],
     });
   });
 
   test("am not in", async () => {
-    await withDb(async (db) => {
-      const notExpected = await addLeague(db, { name: "My league" });
-      const expected = await addLeague(db, { name: "not my league" });
-      await (
-        await db.users()
-      ).edit(user._id, { $set: { leagues: [notExpected._id] } });
+    const notExpected = await addLeague(db.get(), { name: "My league" });
+    const expected = await addLeague(db.get(), { name: "not my league" });
+    await user.edit({ $set: { leagues: [notExpected._id] } });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/league/find")
-        .send({ query: { amIn: false } })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post("/league/find")
+      .send({ query: { amIn: false } });
 
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [censorLeague(expected)],
-      });
+    console.log(res.body);
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [censorLeague(expected)],
     });
   });
 
   test("query: sport + name", async () => {
-    await withDb(async (db) => {
-      const expected = await addLeague(db, {
-        name: "My league 1",
-        sport: Sport.Tennis,
-      });
-      await addLeague(db, { name: "not my league", sport: Sport.Tennis });
-      await addLeague(db, { name: "league 1", sport: Sport.Badminton });
+    const expected = await addLeague(db.get(), {
+      name: "My league 1",
+      sport: Sport.Tennis,
+    });
+    await addLeague(db.get(), { name: "not my league", sport: Sport.Tennis });
+    await addLeague(db.get(), { name: "league 1", sport: Sport.Badminton });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/league/find")
-        .send({ query: { name: "league 1", sport: Sport.Tennis } })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post("/league/find")
+      .send({ query: { name: "league 1", sport: Sport.Tennis } });
 
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [censorLeague(expected)],
-      });
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [censorLeague(expected)],
     });
   });
 
   test("name in lis", async () => {
-    await withDb(async (db) => {
-      const expected1 = await addLeague(db, {
-        name: "My league 1",
-        sport: Sport.Tennis,
-      });
-      const expected2 = await addLeague(db, {
-        name: "not my league",
-        sport: Sport.Tennis,
-      });
-      await addLeague(db, { name: "league 1", sport: Sport.Badminton });
+    const expected1 = await addLeague(db.get(), {
+      name: "My league 1",
+      sport: Sport.Tennis,
+    });
+    const expected2 = await addLeague(db.get(), {
+      name: "not my league",
+      sport: Sport.Tennis,
+    });
+    await addLeague(db.get(), { name: "league 1", sport: Sport.Badminton });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/league/find")
-        .send({
-          query: {
-            name: { $in: ["My league 1", "not my league"] },
-            sport: Sport.Tennis,
-          },
-        })
-        .set("Authorization", "Bearer test_api_token");
-
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [censorLeague(expected1), censorLeague(expected2)],
+    const res = await user
+      .request(app)
+      .post("/league/find")
+      .send({
+        query: {
+          name: { $in: ["My league 1", "not my league"] },
+          sport: Sport.Tennis,
+        },
       });
+
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [censorLeague(expected1), censorLeague(expected2)],
     });
   });
 
   test("private league", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db, { private: false });
-      await addLeague(db, { private: true });
-      await addUser(db);
+    const league = await addLeague(db.get(), { private: false });
+    await addLeague(db.get(), { private: true });
+    await addUser(db.get());
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/league/find")
-        .send({})
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user.request(app).post("/league/find").send({});
 
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [censorLeague(league)],
-      });
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [censorLeague(league)],
     });
   });
 });
 
 describe("new", () => {
   test("private", async () => {
-    await withDb(async (db) => {
-      const auth0Id = "github|123456";
-      const currUser = await addUser(db, auth0Id);
+    const res = await user
+      .request(app)
+      .post("/league/new")
+      .send({ name: "Something", private: true, sport: Sport.Tennis });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/league/new")
-        .send({ name: "Something", private: true, sport: Sport.Tennis })
-        .set("Authorization", "Bearer test_api_token");
-
-      expect(res.statusCode).toBe(201);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: {
-          _id: expect.any(ObjectId),
-          ownerIds: [currUser._id],
-          name: "Something",
-          sport: Sport.Tennis,
-          private: true,
-          inviteCode: expect.any(String),
-        },
-      });
+    expect(res.statusCode).toBe(201);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: {
+        _id: expect.any(ObjectId),
+        ownerIds: [user.id()],
+        name: "Something",
+        sport: Sport.Tennis,
+        private: true,
+        inviteCode: expect.any(String),
+      },
     });
   });
 });
 
 describe("invite", () => {
-  const auth0Id = "github|123456";
-  let user: User;
-
-  beforeEach(async () => {
-    user = await withDb((db) => addUser(db, auth0Id));
-  });
-
   test("am owner", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db, {
-        ownerIds: [user._id],
-        private: true,
-        inviteCode: "test",
-      });
+    const league = await addLeague(db.get(), {
+      ownerIds: [user.id()],
+      private: true,
+      inviteCode: "test",
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .get(`/league/${league._id.toString()}/invite`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .get(`/league/${league._id.toString()}/invite`);
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({
-        success: true,
-        data: "test",
-      });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({
+      success: true,
+      data: "test",
     });
   });
 
   test("not owner", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db, {
-        private: true,
-        inviteCode: "test",
-      });
+    const league = await addLeague(db.get(), {
+      private: true,
+      inviteCode: "test",
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .get(`/league/${league._id.toString()}/invite`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .get(`/league/${league._id.toString()}/invite`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 
   test("doesn't exist", async () => {
-    const res = await requestWithAuth(app, auth0Id)
-      .get(`/league/${IDS[0]}/invite`)
-      .set("Authorization", "Bearer test_api_token");
+    const res = await user.request(app).get(`/league/${IDS[0]}/invite`);
 
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({
@@ -247,147 +196,119 @@ describe("invite", () => {
 });
 
 describe("join", () => {
-  const auth0Id = "github|111112";
-  let user: User;
-
   beforeEach(async () => {
-    user = await withDb((db) => addUser(db, auth0Id, { leagues: [] }));
+    await user.edit({ $set: { leagues: [] } });
   });
 
   test("public", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db);
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/league/${league._id.toString()}/join`)
-        .set("Authorization", "Bearer test_api_token");
+    const league = await addLeague(db.get());
+    const res = await user
+      .request(app)
+      .post(`/league/${league._id.toString()}/join`);
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({ success: true });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({ success: true });
 
-      const u = await (await db.users()).get(user._id);
-      expect(u?.leagues).toStrictEqual([league._id]);
-    });
+    const u = await user.update();
+    expect(u.leagues).toStrictEqual([league._id]);
   });
 
   test("not found", async () => {
-    await withDb(async (db) => {
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/league/${IDS[0]}/join`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user.request(app).post(`/league/${IDS[0]}/join`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
-
-      const u = await (await db.users()).get(user._id);
-      expect(u?.leagues).toStrictEqual([]);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
+
+    const u = await user.update();
+    expect(u.leagues).toStrictEqual([]);
   });
 
   test("already in", async () => {
-    await withDb(async (db) => {
-      await (
-        await db.users()
-      ).edit(user._id, { $set: { leagues: [new ObjectId(IDS[0])] } });
+    await user.edit({ $set: { leagues: [OIDS[0]] } });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/league/${IDS[0]}/join`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user.request(app).post(`/league/${IDS[0]}/join`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
-
-      const u = await (await db.users()).get(user._id);
-      expect(u?.leagues).toStrictEqual([new ObjectId(IDS[0])]);
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
+
+    const u = await user.update();
+    expect(u.leagues).toStrictEqual([OIDS[0]]);
   });
 
   describe("private", () => {
     test("have invite code", async () => {
-      await withDb(async (db) => {
-        const league = await addLeague(db, {
-          private: true,
-          inviteCode: "test",
-        });
-
-        const res = await requestWithAuth(app, auth0Id)
-          .post(`/league/${league._id.toString()}/join`)
-          .send({ inviteCode: "test" })
-          .set("Authorization", "Bearer test_api_token");
-
-        expect(res.statusCode).toBe(200);
-        expect(res.body).toStrictEqual({ success: true });
-
-        const u = await (await db.users()).get(user._id);
-        expect(u?.leagues).toStrictEqual([league._id]);
+      const league = await addLeague(db.get(), {
+        private: true,
+        inviteCode: "test",
       });
+
+      const res = await user
+        .request(app)
+        .post(`/league/${league._id.toString()}/join`)
+        .send({ inviteCode: "test" });
+
+      expect(res.statusCode).toBe(200);
+      expect(res.body).toStrictEqual({ success: true });
+
+      const u = await user.update();
+      expect(u.leagues).toStrictEqual([league._id]);
     });
 
     test("no invite code", async () => {
-      await withDb(async (db) => {
-        const league = await addLeague(db, {
-          private: true,
-          inviteCode: "test",
-        });
-
-        const res = await requestWithAuth(app, auth0Id)
-          .post(`/league/${league._id.toString()}/join`)
-          .set("Authorization", "Bearer test_api_token");
-
-        expect(res.statusCode).toBe(404);
-        expect(res.body).toStrictEqual({
-          success: false,
-          error: "Failed to get obj",
-        });
-
-        const u = await (await db.users()).get(user._id);
-        expect(u?.leagues).toStrictEqual([]);
+      const league = await addLeague(db.get(), {
+        private: true,
+        inviteCode: "test",
       });
+
+      const res = await user
+        .request(app)
+        .post(`/league/${league._id.toString()}/join`);
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toStrictEqual({
+        success: false,
+        error: "Failed to get obj",
+      });
+
+      const u = await user.update();
+      expect(u.leagues).toStrictEqual([]);
     });
 
     test("wrong invite code", async () => {
-      await withDb(async (db) => {
-        const league = await addLeague(db, {
-          private: true,
-          inviteCode: "test",
-        });
-
-        const res = await requestWithAuth(app, auth0Id)
-          .post(`/league/${league._id.toString()}/join`)
-          .send({ inviteCode: "nope" })
-          .set("Authorization", "Bearer test_api_token");
-
-        expect(res.statusCode).toBe(404);
-        expect(res.body).toStrictEqual({
-          success: false,
-          error: "Failed to get obj",
-        });
-
-        const u = await (await db.users()).get(user._id);
-        expect(u?.leagues).toStrictEqual([]);
+      const league = await addLeague(db.get(), {
+        private: true,
+        inviteCode: "test",
       });
+
+      const res = await user
+        .request(app)
+        .post(`/league/${league._id.toString()}/join`)
+        .send({ inviteCode: "nope" });
+
+      expect(res.statusCode).toBe(404);
+      expect(res.body).toStrictEqual({
+        success: false,
+        error: "Failed to get obj",
+      });
+
+      const u = await user.update();
+      expect(u.leagues).toStrictEqual([]);
     });
   });
 });
 
 describe("edit", () => {
-  const auth0Id = "github|111112";
-  let user: User;
-
-  beforeEach(async () => {
-    user = await withDb((db) => addUser(db, auth0Id, { leagues: [] }));
-  });
-
   test("doesn't exist", async () => {
-    const res = await requestWithAuth(app, auth0Id)
+    const res = await user
+      .request(app)
       .post(`/league/${IDS[0]}/edit`)
-      .send({ name: "HI!" })
-      .set("Authorization", "Bearer test_api_token");
+      .send({ name: "HI!" });
 
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({
@@ -397,42 +318,38 @@ describe("edit", () => {
   });
 
   test("not owner", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db);
+    const league = await addLeague(db.get());
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/league/${league._id.toString()}/edit`)
-        .send({ name: "HI!" })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/league/${league._id.toString()}/edit`)
+      .send({ name: "HI!" });
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
-
-      const edittedLeague = await (await db.leagues()).get(league._id);
-      expect(edittedLeague?.name).not.toBe("HI!");
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
+
+    const edittedLeague = await (await db.get().leagues()).get(league._id);
+    expect(edittedLeague?.name).not.toBe("HI!");
   });
 
   test("am owner", async () => {
-    await withDb(async (db) => {
-      const league = await addLeague(db, { ownerIds: [user._id] });
+    const league = await addLeague(db.get(), { ownerIds: [user.id()] });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/league/${league._id.toString()}/edit`)
-        .send({ name: "HI!" })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/league/${league._id.toString()}/edit`)
+      .send({ name: "HI!" });
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({
-        success: true,
-      });
-
-      const edittedLeague = await (await db.leagues()).get(league._id);
-      expect(edittedLeague?.name).toBe("HI!");
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({
+      success: true,
     });
+
+    const edittedLeague = await (await db.get().leagues()).get(league._id);
+    expect(edittedLeague?.name).toBe("HI!");
   });
 });
 
@@ -445,11 +362,11 @@ addCommonTests({
       private: false,
     } as LeagueCreation;
   },
-  addObj: (db, _, creation) => addLeague(db, creation),
-  addCensoredObj: async (db) =>
-    censorLeague(await addLeague(db, { name: generateRandomString() })),
-  validateCreation: async (db, currUser) => {
-    const coll = await db.leagues();
+  addObj: (_, creation) => addLeague(db.get(), creation),
+  addCensoredObj: async () =>
+    censorLeague(await addLeague(db.get(), { name: generateRandomString() })),
+  validateCreation: async (currUser) => {
+    const coll = await db.get().leagues();
     const res = await coll.find({});
     expect(res).toStrictEqual([
       {

--- a/packages/backend/tests/controllers/match.test.ts
+++ b/packages/backend/tests/controllers/match.test.ts
@@ -27,8 +27,9 @@ describe("accept", () => {
   test("done", async () => {
     const match = await addMatch(db.get(), {
       status: MatchStatus.Request,
-      players: [user.id(), OIDS[0]],
+      players: [OIDS[0], user.id()],
     });
+
     const res = await user
       .request(app)
       .post(`/match/${match._id.toString()}/accept`);
@@ -46,7 +47,7 @@ describe("accept", () => {
   test("match already accepted", async () => {
     const match = await addMatch(db.get(), {
       status: MatchStatus.Accepted,
-      players: [user.id(), OIDS[0]],
+      players: [OIDS[0], user.id()],
     });
 
     const res = await user

--- a/packages/backend/tests/controllers/match.test.ts
+++ b/packages/backend/tests/controllers/match.test.ts
@@ -5,83 +5,63 @@ import type {
   MatchQuery,
   PageOptions,
   Scores,
-  User,
 } from "@esp-group-one/types";
-import { MatchStatus, ObjectId, Sport, tests } from "@esp-group-one/types";
+import { MatchStatus, ObjectId, Sport } from "@esp-group-one/types";
 import { describe, expect, test } from "@jest/globals";
-import { addCommonTests, setup, withDb } from "../helpers/controller.js";
-import {
-  addMatch,
-  addUser,
-  expectAPIRes,
-  requestWithAuth,
-} from "../helpers/utils.js";
+import { IDS, OIDS, addMatch } from "@esp-group-one/test-helpers";
+import { addCommonTests, setup } from "../helpers/controller.js";
+import { expectAPIRes } from "../helpers/utils.js";
 import { app } from "../../src/app.js";
+import { TestUser } from "../helpers/user.js";
 
-const { IDS } = tests;
-
-setup();
+const db = setup();
 
 jest.mock("access-token-jwt");
 
 const creationStartDate = new Date().toString();
 
-const auth0Id = "github|111112";
-let user: User;
-let opponent: User;
-
-beforeEach(async () => {
-  await withDb(async (db) => {
-    user = await addUser(db, auth0Id);
-    opponent = await addUser(db, auth0Id);
-  });
-});
+const user = new TestUser(db, "github|111112");
+const opponent = new TestUser(db, "github|111113");
 
 describe("accept", () => {
   test("done", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Request,
-        players: [user._id, new ObjectId(IDS[0])],
-      });
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/accept`)
-        .set("Authorization", "Bearer test_api_token");
-
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({
-        success: true,
-      });
-
-      const matches = await db.matches();
-      const updateMatch = await matches.get(match._id);
-      expect(updateMatch?.status).toBe(MatchStatus.Accepted);
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Request,
+      players: [user.id(), OIDS[0]],
     });
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/accept`);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({
+      success: true,
+    });
+
+    const matches = await db.get().matches();
+    const updateMatch = await matches.get(match._id);
+    expect(updateMatch?.status).toBe(MatchStatus.Accepted);
   });
 
   test("match already accepted", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        players: [user._id, new ObjectId(IDS[0])],
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      players: [user.id(), OIDS[0]],
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/accept`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/accept`);
 
-      expect(res.statusCode).toBe(400);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "The match is already accepted",
-      });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "The match is already accepted",
     });
   });
 
   test("match doesn't exist", async () => {
-    const res = await requestWithAuth(app, auth0Id)
-      .post(`/match/${IDS[0]}/accept`)
-      .set("Authorization", "Bearer test_api_token");
+    const res = await user.request(app).post(`/match/${IDS[0]}/accept`);
 
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({
@@ -91,86 +71,80 @@ describe("accept", () => {
   });
 
   test("user is owner", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        players: [user._id, new ObjectId(IDS[0])],
-        owner: user._id,
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      players: [user.id(), OIDS[0]],
+      owner: user.id(),
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/accept`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/accept`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 
   test("user not in players", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        players: [new ObjectId(IDS[0]), new ObjectId(IDS[1])],
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      players: [OIDS[0], OIDS[1]],
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/accept`)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/accept`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 });
 
 describe("complete", () => {
   test("success", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        players: [user._id, opponent._id],
-      });
-
-      const scores: Scores = newScores([
-        [user._id.toString(), 10],
-        [opponent._id.toString(), 5],
-      ]);
-
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/complete`)
-        .send(scores)
-        .set("Authorization", "Bearer test_api_token");
-
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({
-        success: true,
-      });
-
-      const matches = await db.matches();
-      const updateMatch = await matches.get(match._id);
-      expect(updateMatch?.status).toBe(MatchStatus.Complete);
-      if (updateMatch?.status === MatchStatus.Complete) {
-        expect(updateMatch.score).toStrictEqual(scores);
-      }
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      players: [user.id(), opponent.id()],
     });
+
+    const scores: Scores = newScores([
+      [user.id().toString(), 10],
+      [opponent.id().toString(), 5],
+    ]);
+
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/complete`)
+      .send(scores);
+
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({
+      success: true,
+    });
+
+    const matches = await db.get().matches();
+    const updateMatch = await matches.get(match._id);
+    expect(updateMatch?.status).toBe(MatchStatus.Complete);
+    if (updateMatch?.status === MatchStatus.Complete) {
+      expect(updateMatch.score).toStrictEqual(scores);
+    }
   });
 
   test("doesn't exist", async () => {
     const scores: Scores = newScores([
-      [user._id.toString(), 10],
+      [user.id().toString(), 10],
       [IDS[0], 5],
     ]);
-    const res = await requestWithAuth(app, auth0Id)
+    const res = await user
+      .request(app)
       .post(`/match/${IDS[1]}/complete`)
-      .send(scores)
-      .set("Authorization", "Bearer test_api_token");
+      .send(scores);
 
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({
@@ -180,154 +154,142 @@ describe("complete", () => {
   });
 
   test("not in players", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+    });
 
-      const scores: Scores = newScores([
-        [user._id.toString(), 10],
-        [opponent._id.toString(), 5],
-      ]);
+    const scores: Scores = newScores([
+      [user.id().toString(), 10],
+      [opponent.id().toString(), 5],
+    ]);
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/complete`)
-        .send(scores)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/complete`)
+      .send(scores);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 
   describe("not in accepting state", () => {
     [MatchStatus.Complete, MatchStatus.Request].forEach((status) => {
       test(status.toString(), async () => {
-        await withDb(async (db) => {
-          const match = await addMatch(db, {
-            status,
-            players: [user._id, opponent._id],
-          });
+        const match = await addMatch(db.get(), {
+          status,
+          players: [user.id(), opponent.id()],
+        });
 
-          const scores: Scores = newScores([
-            [user._id.toString(), 10],
-            [opponent._id.toString(), 5],
-          ]);
+        const scores: Scores = newScores([
+          [user.id().toString(), 10],
+          [opponent.id().toString(), 5],
+        ]);
 
-          const res = await requestWithAuth(app, auth0Id)
-            .post(`/match/${match._id.toString()}/complete`)
-            .send(scores)
-            .set("Authorization", "Bearer test_api_token");
+        const res = await user
+          .request(app)
+          .post(`/match/${match._id.toString()}/complete`)
+          .send(scores);
 
-          expect(res.statusCode).toBe(400);
-          expect(res.body).toStrictEqual({
-            success: false,
-            error: "The match is not in accepted state",
-          });
+        expect(res.statusCode).toBe(400);
+        expect(res.body).toStrictEqual({
+          success: false,
+          error: "The match is not in accepted state",
         });
       });
     });
   });
 
   test("before completion date", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        players: [user._id, opponent._id],
-        date: new Date(Date.now() + 12096e5).toString(),
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      players: [user.id(), opponent.id()],
+      date: new Date(Date.now() + 12096e5).toString(),
+    });
 
-      const scores: Scores = newScores([
-        [user._id.toString(), 10],
-        [opponent._id.toString(), 5],
-      ]);
+    const scores: Scores = newScores([
+      [user.id().toString(), 10],
+      [opponent.id().toString(), 5],
+    ]);
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/complete`)
-        .send(scores)
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/complete`)
+      .send(scores);
 
-      expect(res.statusCode).toBe(400);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "The match has not started",
-      });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "The match has not started",
     });
   });
 
   describe("invalid scores", () => {
     test("duplicate players", async () => {
-      await withDb(async (db) => {
-        const match = await addMatch(db, {
-          status: MatchStatus.Accepted,
-          players: [user._id, opponent._id],
-        });
+      const match = await addMatch(db.get(), {
+        status: MatchStatus.Accepted,
+        players: [user.id(), opponent.id()],
+      });
 
-        const scores: Scores = newScores([
-          [user._id.toString(), 10],
-          [user._id.toString(), 5],
-        ]);
+      const scores: Scores = newScores([
+        [user.id().toString(), 10],
+        [user.id().toString(), 5],
+      ]);
 
-        const res = await requestWithAuth(app, auth0Id)
-          .post(`/match/${match._id.toString()}/complete`)
-          .send(scores)
-          .set("Authorization", "Bearer test_api_token");
+      const res = await user
+        .request(app)
+        .post(`/match/${match._id.toString()}/complete`)
+        .send(scores);
 
-        expect(res.statusCode).toBe(400);
-        expect(res.body).toStrictEqual({
-          success: false,
-          error: "The number of scores + players does not match",
-        });
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toStrictEqual({
+        success: false,
+        error: "The number of scores + players does not match",
       });
     });
 
     test("with players not in match", async () => {
-      await withDb(async (db) => {
-        const match = await addMatch(db, {
-          status: MatchStatus.Accepted,
-          players: [user._id, opponent._id],
-        });
+      const match = await addMatch(db.get(), {
+        status: MatchStatus.Accepted,
+        players: [user.id(), opponent.id()],
+      });
 
-        const scores: Scores = newScores([
-          [user._id.toString(), 10],
-          [IDS[1], 5],
-        ]);
+      const scores: Scores = newScores([
+        [user.id().toString(), 10],
+        [IDS[1], 5],
+      ]);
 
-        const res = await requestWithAuth(app, auth0Id)
-          .post(`/match/${match._id.toString()}/complete`)
-          .send(scores)
-          .set("Authorization", "Bearer test_api_token");
+      const res = await user
+        .request(app)
+        .post(`/match/${match._id.toString()}/complete`)
+        .send(scores);
 
-        expect(res.statusCode).toBe(400);
-        expect(res.body).toStrictEqual({
-          success: false,
-          error: "The number of scores + players does not match",
-        });
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toStrictEqual({
+        success: false,
+        error: "The number of scores + players does not match",
       });
     });
 
     test("with less players", async () => {
-      await withDb(async (db) => {
-        const match = await addMatch(db, {
-          status: MatchStatus.Accepted,
-          players: [user._id, opponent._id],
-        });
+      const match = await addMatch(db.get(), {
+        status: MatchStatus.Accepted,
+        players: [user.id(), opponent.id()],
+      });
 
-        const scores: Scores = newScores([[user._id.toString(), 10]]);
+      const scores: Scores = newScores([[user.id().toString(), 10]]);
 
-        const res = await requestWithAuth(app, auth0Id)
-          .post(`/match/${match._id.toString()}/complete`)
-          .send(scores)
-          .set("Authorization", "Bearer test_api_token");
+      const res = await user
+        .request(app)
+        .post(`/match/${match._id.toString()}/complete`)
+        .send(scores);
 
-        expect(res.statusCode).toBe(400);
-        expect(res.body).toStrictEqual({
-          success: false,
-          error: "The number of scores + players does not match",
-        });
+      expect(res.statusCode).toBe(400);
+      expect(res.body).toStrictEqual({
+        success: false,
+        error: "The number of scores + players does not match",
       });
     });
   });
@@ -335,10 +297,10 @@ describe("complete", () => {
 
 describe("new", () => {
   test("with yourself", async () => {
-    const res = await requestWithAuth(app, auth0Id)
+    const res = await user
+      .request(app)
       .post("/match/new")
-      .send(getMatchProposal({ to: user._id }))
-      .set("Authorization", "Bearer test_api_thing");
+      .send(getMatchProposal({ to: user.id() }));
 
     expect(res.status).toBe(400);
     expect(res.body).toStrictEqual({
@@ -348,10 +310,10 @@ describe("new", () => {
   });
 
   test("invalid time string", async () => {
-    const res = await requestWithAuth(app, auth0Id)
+    const res = await user
+      .request(app)
       .post("/match/new")
-      .send(getMatchProposal({ date: "1982374121897236187" }))
-      .set("Authorization", "Bearer test_api_thing");
+      .send(getMatchProposal({ date: "1982374121897236187" }));
 
     expect(res.status).toBe(400);
     expect(res.body).toStrictEqual({
@@ -361,10 +323,10 @@ describe("new", () => {
   });
 
   test("opponent doesn't exist", async () => {
-    const res = await requestWithAuth(app, auth0Id)
+    const res = await user
+      .request(app)
       .post("/match/new")
-      .send(getMatchProposal({ to: new ObjectId(IDS[0]) }))
-      .set("Authorization", "Bearer test_api_thing");
+      .send(getMatchProposal({ to: OIDS[0] }));
 
     expect(res.status).toBe(400);
     expect(res.body).toStrictEqual({
@@ -372,250 +334,219 @@ describe("new", () => {
       success: false,
     });
   });
+});
 
-  describe("with league", () => {
-    test("user in league", async () => {
-      await withDb(async (db) => {
-        const users = await db.users();
-        await users.edit(user._id, {
-          $set: { leagues: [new ObjectId(IDS[1])] },
-        });
-      });
-
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/match/new")
-        .send(getMatchProposal({ league: new ObjectId(IDS[1]), round: 0 }))
-        .set("Authorization", "Bearer test_api_thing");
-
-      expect(res.status).toBe(201);
-      expectAPIRes(res.body).toEqual({
-        success: true,
-        data: {
-          _id: expect.any(ObjectId),
-          date: creationStartDate,
-          messages: [],
-          owner: user._id,
-          players: [user._id, opponent._id],
-          sport: Sport.Tennis,
-          status: MatchStatus.Request,
-          league: new ObjectId(IDS[1]),
-          round: 0,
-        },
-      });
+describe("with league", () => {
+  test("user in league", async () => {
+    await user.edit({
+      $set: { leagues: [OIDS[1]] },
     });
 
-    test("user not in league", async () => {
-      const res = await requestWithAuth(app, auth0Id)
-        .post("/match/new")
-        .send(getMatchProposal({ league: new ObjectId(IDS[0]), round: 0 }))
-        .set("Authorization", "Bearer test_api_thing");
+    const res = await user
+      .request(app)
+      .post("/match/new")
+      .send(getMatchProposal({ league: OIDS[1], round: 0 }));
 
-      expect(res.status).toBe(400);
-      expectAPIRes(res.body).toEqual({
-        success: false,
-        error: "You must be in the league to create a match",
-      });
+    expect(res.status).toBe(201);
+    expectAPIRes(res.body).toEqual({
+      success: true,
+      data: {
+        _id: expect.any(ObjectId),
+        date: creationStartDate,
+        messages: [],
+        owner: user.id(),
+        players: [user.id(), opponent.id()],
+        sport: Sport.Tennis,
+        status: MatchStatus.Request,
+        league: OIDS[1],
+        round: 0,
+      },
+    });
+  });
+
+  test("user not in league", async () => {
+    const res = await user
+      .request(app)
+      .post("/match/new")
+      .send(getMatchProposal({ league: OIDS[0], round: 0 }));
+
+    expect(res.status).toBe(400);
+    expectAPIRes(res.body).toEqual({
+      success: false,
+      error: "You must be in the league to create a match",
     });
   });
 });
 
 describe("get", () => {
   test("not your match", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db);
-      const res = await requestWithAuth(app, auth0Id)
-        .get(`/match/${match._id.toString()}`)
-        .set("Authorization", "Bearer test_api_token");
+    const match = await addMatch(db.get());
+    const res = await user.request(app).get(`/match/${match._id.toString()}`);
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 });
 
 describe("find/proposed", () => {
   test("general", async () => {
-    await withDb(async (db) => {
-      const matches: Match[] = [];
-      matches.push(
-        await addMatch(db, {
-          status: MatchStatus.Accepted,
-          owner: user._id,
-          players: [user._id, new ObjectId(IDS[0])],
-        }),
-      );
+    const matches: Match[] = [];
+    matches.push(
+      await addMatch(db.get(), {
+        status: MatchStatus.Accepted,
+        owner: user.id(),
+        players: [user.id(), OIDS[0]],
+      }),
+      await addMatch(db.get(), {
+        status: MatchStatus.Accepted,
+        owner: OIDS[0],
+        players: [user.id(), OIDS[0]],
+      }),
+      await addMatch(db.get(), {
+        status: MatchStatus.Accepted,
+        owner: OIDS[0],
+        players: [OIDS[0], OIDS[1]],
+      }),
+    );
 
-      matches.push(
-        await addMatch(db, {
-          status: MatchStatus.Accepted,
-          owner: new ObjectId(IDS[0]),
-          players: [user._id, new ObjectId(IDS[0])],
-        }),
-      );
+    const res = await user.request(app).post(`/match/find/proposed`);
 
-      matches.push(
-        await addMatch(db, {
-          status: MatchStatus.Accepted,
-          owner: new ObjectId(IDS[0]),
-          players: [new ObjectId(IDS[0]), new ObjectId(IDS[1])],
-        }),
-      );
-
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/find/proposed`)
-        .set("Authorization", "Bearer test_api_token");
-
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [matches[1]],
-      });
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [matches[1]],
     });
   });
 });
 
 describe("find", () => {
   test("not your match", async () => {
-    await withDb(async (db) => {
-      await addMatch(db);
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/find`)
-        .send({})
-        .set("Authorization", "Bearer test_api_token");
+    await addMatch(db.get());
+    const res = await user.request(app).post(`/match/find`).send({});
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({
-        success: true,
-        data: [],
-      });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({
+      success: true,
+      data: [],
     });
   });
 
   test("with query", async () => {
-    await withDb(async (db) => {
-      const expected = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        owner: user._id,
-        players: [user._id, new ObjectId(IDS[0])],
-      });
-      await addMatch(db);
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/find`)
-        .send({
-          query: { status: MatchStatus.Accepted },
-        } as PageOptions<MatchQuery>)
-        .set("Authorization", "Bearer test_api_token");
+    const expected = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      owner: user.id(),
+      players: [user.id(), OIDS[0]],
+    });
+    await addMatch(db.get());
+    const res = await user
+      .request(app)
+      .post(`/match/find`)
+      .send({
+        query: { status: MatchStatus.Accepted },
+      } as PageOptions<MatchQuery>);
 
-      expect(res.statusCode).toBe(200);
-      expectAPIRes(res.body).toStrictEqual({
-        success: true,
-        data: [expected],
-      });
+    expect(res.statusCode).toBe(200);
+    expectAPIRes(res.body).toStrictEqual({
+      success: true,
+      data: [expected],
     });
   });
 });
 
 describe("rate", () => {
   test("done", async () => {
-    await withDb(async (db) => {
-      const users = await db.users();
-      await users.edit(user._id, {
-        $set: { rating: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } },
-      });
-      await users.edit(opponent._id, {
-        $set: { rating: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } },
-      });
+    await user.edit({
+      $set: { rating: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } },
+    });
+    await opponent.edit({
+      $set: { rating: { 1: 0, 2: 0, 3: 0, 4: 0, 5: 0 } },
+    });
 
-      const match = await addMatch(db, {
-        status: MatchStatus.Complete,
-        players: [user._id, opponent._id],
-      });
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/rate`)
-        .send({ stars: 5 })
-        .set("Authorization", "Bearer test_api_token");
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Complete,
+      players: [user.id(), opponent.id()],
+    });
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/rate`)
+      .send({ stars: 5 });
 
-      expect(res.statusCode).toBe(200);
-      expect(res.body).toStrictEqual({
-        success: true,
-      });
+    expect(res.statusCode).toBe(200);
+    expect(res.body).toStrictEqual({
+      success: true,
+    });
 
-      const matches = await db.matches();
-      const updateMatch = await matches.get(match._id);
-      expect(updateMatch?.status).toBe(MatchStatus.Complete);
-      if (updateMatch?.status === MatchStatus.Complete) {
-        expect(updateMatch.usersRated).toStrictEqual([user._id]);
-      }
+    const matches = await db.get().matches();
+    const updateMatch = await matches.get(match._id);
+    expect(updateMatch?.status).toBe(MatchStatus.Complete);
+    if (updateMatch?.status === MatchStatus.Complete) {
+      expect(updateMatch.usersRated).toStrictEqual([user.id()]);
+    }
 
-      const updateUser = await users.get(user._id);
-      expect(updateUser?.rating).toStrictEqual({
-        1: 0,
-        2: 0,
-        3: 0,
-        4: 0,
-        5: 0,
-      });
+    const updateUser = await user.update();
+    expect(updateUser.rating).toStrictEqual({
+      1: 0,
+      2: 0,
+      3: 0,
+      4: 0,
+      5: 0,
+    });
 
-      const updateOpponent = await users.get(opponent._id);
-      expect(updateOpponent?.rating).toStrictEqual({
-        1: 0,
-        2: 0,
-        3: 0,
-        4: 0,
-        5: 1,
-      });
+    const updateOpponent = await opponent.update();
+    expect(updateOpponent.rating).toStrictEqual({
+      1: 0,
+      2: 0,
+      3: 0,
+      4: 0,
+      5: 1,
     });
   });
 
   test("match not completed", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Accepted,
-        players: [user._id, new ObjectId(IDS[0])],
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Accepted,
+      players: [user.id(), OIDS[0]],
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/rate`)
-        .send({ stars: 5 })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/rate`)
+      .send({ stars: 5 });
 
-      expect(res.statusCode).toBe(400);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "The match has not completed",
-      });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "The match has not completed",
     });
   });
 
   test("match already rated", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Complete,
-        players: [user._id, new ObjectId(IDS[0])],
-        usersRated: [user._id],
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Complete,
+      players: [user.id(), OIDS[0]],
+      usersRated: [user.id()],
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/rate`)
-        .send({ stars: 5 })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/rate`)
+      .send({ stars: 5 });
 
-      expect(res.statusCode).toBe(400);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "You have already rated the match!",
-      });
+    expect(res.statusCode).toBe(400);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "You have already rated the match!",
     });
   });
 
   test("match doesn't exist", async () => {
-    const res = await requestWithAuth(app, auth0Id)
+    const res = await user
+      .request(app)
       .post(`/match/${IDS[0]}/rate`)
-      .send({ stars: 5 })
-      .set("Authorization", "Bearer test_api_token");
+      .send({ stars: 5 });
 
     expect(res.statusCode).toBe(404);
     expect(res.body).toStrictEqual({
@@ -625,22 +556,20 @@ describe("rate", () => {
   });
 
   test("user not in players", async () => {
-    await withDb(async (db) => {
-      const match = await addMatch(db, {
-        status: MatchStatus.Complete,
-        players: [new ObjectId(IDS[0]), new ObjectId(IDS[1])],
-      });
+    const match = await addMatch(db.get(), {
+      status: MatchStatus.Complete,
+      players: [OIDS[0], OIDS[1]],
+    });
 
-      const res = await requestWithAuth(app, auth0Id)
-        .post(`/match/${match._id.toString()}/rate`)
-        .send({ stars: 5 })
-        .set("Authorization", "Bearer test_api_token");
+    const res = await user
+      .request(app)
+      .post(`/match/${match._id.toString()}/rate`)
+      .send({ stars: 5 });
 
-      expect(res.statusCode).toBe(404);
-      expect(res.body).toStrictEqual({
-        success: false,
-        error: "Failed to get obj",
-      });
+    expect(res.statusCode).toBe(404);
+    expect(res.body).toStrictEqual({
+      success: false,
+      error: "Failed to get obj",
     });
   });
 });
@@ -649,11 +578,11 @@ addCommonTests({
   prefix: "/match",
   getCreation: () => getMatchProposal({}),
   skipNewExists: true,
-  addObj: (db, _, creation) => addMatch(db, creation),
-  addCensoredObj: (db, currUser) =>
-    addMatch(db, { players: [currUser._id, opponent._id] }),
-  validateCreation: async (db, currUser) => {
-    const coll = await db.matches();
+  addObj: (_, creation) => addMatch(db.get(), creation),
+  addCensoredObj: (currUser) =>
+    addMatch(db.get(), { players: [currUser._id, opponent.id()] }),
+  validateCreation: async (currUser) => {
+    const coll = await db.get().matches();
     const res = await coll.find({});
     expect(res).toStrictEqual([
       {
@@ -661,7 +590,7 @@ addCommonTests({
         date: creationStartDate,
         messages: [],
         owner: currUser._id,
-        players: [currUser._id, opponent._id],
+        players: [currUser._id, opponent.id()],
         sport: Sport.Tennis,
         status: MatchStatus.Request,
       },
@@ -672,14 +601,14 @@ addCommonTests({
 function getMatchProposal(inp: Partial<MatchProposal>): MatchProposal {
   const base: MatchProposal = {
     date: inp.date ?? creationStartDate,
-    to: inp.to ?? opponent._id,
+    to: inp.to ?? opponent.id(),
     sport: inp.sport ?? Sport.Tennis,
   };
 
   if ("league" in inp || "round" in inp) {
     return {
       ...base,
-      league: inp.league ?? new ObjectId(IDS[0]),
+      league: inp.league ?? OIDS[0],
       round: inp.round ?? 0,
     };
   }

--- a/packages/backend/tests/helpers/mock.ts
+++ b/packages/backend/tests/helpers/mock.ts
@@ -1,8 +1,0 @@
-// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required by jest
-type MockableFunction = (...args: any[]) => any;
-
-export function asFuncMock<T extends MockableFunction>(
-  mock: T,
-): jest.MockedFunction<T> {
-  return mock as unknown as jest.MockedFunction<T>;
-}

--- a/packages/backend/tests/helpers/user.ts
+++ b/packages/backend/tests/helpers/user.ts
@@ -1,0 +1,50 @@
+import type { TestDb } from "@esp-group-one/test-helpers";
+import { addUser } from "@esp-group-one/test-helpers";
+import type { ObjectId, User } from "@esp-group-one/types";
+import type { App } from "supertest/types.js";
+import type { UpdateFilter } from "mongodb";
+import { requestWithAuth } from "./utils.js";
+
+/**
+ * Allows you to easily setup a DB and have it properly closed once the tests
+ * are over
+ */
+export class TestUser {
+  auth0Id: string;
+  #user: User | undefined;
+  #db: TestDb;
+
+  constructor(db: TestDb, auth0Id?: string, base?: Partial<User>) {
+    this.auth0Id = auth0Id ?? "github|12345";
+    this.#db = db;
+    beforeEach(async () => {
+      this.#user = await addUser(this.#db.get(), this.auth0Id, base);
+    });
+  }
+
+  get(): User {
+    if (!this.#user)
+      throw new Error("User is not defined, this is outside a test");
+
+    return this.#user;
+  }
+
+  id(): ObjectId {
+    return this.get()._id;
+  }
+
+  async edit(query: UpdateFilter<User>) {
+    const users = await this.#db.get().users();
+    await users.edit(this.get()._id, query);
+  }
+
+  request(app: App) {
+    return requestWithAuth(app, this.auth0Id);
+  }
+
+  async update(): Promise<User> {
+    const users = await this.#db.get().users();
+    this.#user = await users.get(this.get()._id);
+    return this.get();
+  }
+}

--- a/packages/backend/tests/helpers/utils.ts
+++ b/packages/backend/tests/helpers/utils.ts
@@ -1,18 +1,13 @@
 import type { VerifyJwtResult } from "access-token-jwt";
 import { jwtVerifier } from "access-token-jwt";
-import type { DbClient } from "@esp-group-one/db-client";
-import type { League, Match, MongoDBItem, User } from "@esp-group-one/types";
-import { tests as typeTests, ObjectId } from "@esp-group-one/types";
+import { ObjectId } from "@esp-group-one/types";
 import { expect } from "@jest/globals";
-import type { OptionalId } from "mongodb";
 import request from "supertest";
 import type { App } from "supertest/types.js";
-import { asFuncMock } from "./mock.js";
+import { asFuncMock } from "@esp-group-one/test-helpers";
+import type Test from "supertest/lib/test.js";
 
-jest.mock("access-token-jwt");
 const mockedJWTVerifier = asFuncMock(jwtVerifier);
-
-const { getLeague, getMatch, getUser } = typeTests;
 
 export function expectAPIRes<T>(inp: T) {
   return expect(ObjectId.fromObj(inp) as T);
@@ -30,56 +25,29 @@ export function requestWithAuth(pkg: App, auth0Id = "github|123456") {
       return Promise.reject(new Error("Invalid user"));
     });
   }
-  return request(pkg);
+  return new AuthWrapper(pkg);
 }
 
-export async function addUser(
-  db: DbClient,
-  auth0Id = "github|123456",
-  base: Partial<User> = {},
-): Promise<User> {
-  const user: OptionalId<User> = getUser(base);
-  delete user._id;
-  const insert = await (await db.users()).insert(user);
-  const u: User = { ...user, _id: insert[0] };
+export class AuthWrapper {
+  app: App;
 
-  await (await db.userMap()).insert({ auth0Id, internalId: u._id });
+  constructor(app: App) {
+    this.app = app;
+  }
 
-  return u;
-}
+  get(url: string) {
+    return this.setHeader(this.request().get(url));
+  }
 
-export async function addLeague(
-  db: DbClient,
-  base: Partial<League> = {},
-): Promise<League> {
-  const league: OptionalId<League> = getLeague(base);
-  delete league._id;
-  const insert = await (await db.leagues()).insert(league);
-  const l: League = { ...league, _id: insert[0] };
+  post(url: string) {
+    return this.setHeader(this.request().post(url));
+  }
 
-  return l;
-}
+  private request() {
+    return request(this.app);
+  }
 
-export async function addMatch(
-  db: DbClient,
-  base: Partial<Match> = {},
-): Promise<Match> {
-  const match: OptionalId<Match> = getMatch(base);
-  delete match._id;
-  const insert = await (await db.matches()).insert(match);
-  const m: Match = { ...match, _id: insert[0] };
-
-  return m;
-}
-
-export function idCmp<T extends MongoDBItem>(a: T, b: T): number {
-  return a._id.mongoDbId.localeCompare(b._id.mongoDbId);
-}
-
-export function compareBag<T>(
-  got: T[],
-  expected: T[],
-  cmp?: (a: T, b: T) => number,
-) {
-  expect(got.sort(cmp)).toStrictEqual(expected.sort(cmp));
+  private setHeader(t: Test) {
+    return t.set("Authorization", "Bearer test_api_token");
+  }
 }

--- a/packages/backend/tests/lib/db.test.ts
+++ b/packages/backend/tests/lib/db.test.ts
@@ -1,10 +1,10 @@
 import { afterEach, describe, expect, test } from "@jest/globals";
-import * as db from "@esp-group-one/db-client";
+import { db } from "@esp-group-one/test-helpers";
 import { closeDb, getDb } from "../../src/lib/db.js";
 
 // So mongodb doesn't complain
 beforeAll(() => {
-  db.tests.setup();
+  db.setup();
 });
 
 // Makes sure the db is properly closed after all

--- a/packages/db-client/package.json
+++ b/packages/db-client/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "@esp-group-one/eslint-config": "workspace:^",
     "@esp-group-one/jest-esm-transformer": "workspace:^",
+    "@esp-group-one/mongodb-testing": "workspace:^",
     "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.11.7",
@@ -26,7 +27,6 @@
     "typescript": "^5.0.2"
   },
   "dependencies": {
-    "@esp-group-one/mongodb-testing": "workspace:^",
     "@esp-group-one/types": "workspace:^",
     "mongodb": "^6.3.0"
   }

--- a/packages/db-client/src/client.ts
+++ b/packages/db-client/src/client.ts
@@ -31,8 +31,10 @@ export class DbClient {
 
   public async close(): Promise<void> {
     // This makes sure we don't have any async process left
-    await this.db;
-    await this.client.close();
+    if (!this.closed) {
+      await this.db;
+      await this.client.close();
+    }
     this.closed = true;
   }
 
@@ -62,6 +64,14 @@ export class DbClient {
     return this.matchesCache;
   }
 
+  public rawClient(): MongoClient {
+    return this.client;
+  }
+
+  public raw(): Promise<Db> {
+    return this.db;
+  }
+
   public async userMap(): Promise<CollectionWrap<UserIdMap>> {
     const db = await this.db;
 
@@ -88,7 +98,7 @@ export class DbClient {
    * This should only be called in the constructor
    */
   private async connect(): Promise<Db> {
-    await this.client.connect();
+    this.client = await this.client.connect();
 
     return this.client.db(this.dbName);
   }

--- a/packages/db-client/src/index.ts
+++ b/packages/db-client/src/index.ts
@@ -1,4 +1,4 @@
 export * from "./client.js";
 export * from "./constants.js";
 export type { FilterOptions } from "./types.js";
-export * as tests from "../tests/helpers/utils.js";
+export * as helpers from "../tests/helpers/setup.js";

--- a/packages/db-client/tests/client.test.ts
+++ b/packages/db-client/tests/client.test.ts
@@ -1,6 +1,6 @@
 import type { Document, MongoClient, OptionalId } from "mongodb";
 import type { League, Match, User, UserIdMap } from "@esp-group-one/types";
-import { tests } from "@esp-group-one/types";
+import { helpers } from "@esp-group-one/types";
 import { describe, expect, test } from "@jest/globals";
 import { DbClient } from "../src/client.js";
 import {
@@ -10,9 +10,10 @@ import {
   USER_MAP_COLLECTION_NAME,
 } from "../src/constants.js";
 import { toMongo } from "../src/types.js";
-import { getRawClient, getRawDb, setup } from "./helpers/utils.js";
+import { getRawClient, getRawDb } from "./helpers/utils.js";
+import { setup } from "./helpers/setup.js";
 
-const { getLeague, getMatch, getUser, getUserIdMap } = tests;
+const { getLeague, getMatch, getUser, getUserIdMap } = helpers;
 
 let db: DbClient;
 let client: MongoClient;
@@ -74,6 +75,16 @@ describe("collections", () => {
   });
 });
 
+describe("raw", () => {
+  test("db", async () => {
+    await expect(db.raw()).resolves.not.toBeNaN();
+  });
+
+  test("client", () => {
+    expect(db.rawClient()).not.toBeNaN();
+  });
+});
+
 describe("isClosed", () => {
   test("closed", async () => {
     expect(db.isClosed()).toBe(false);
@@ -91,6 +102,7 @@ describe("environmental variables", () => {
       delete process.env.DB_NAME;
       const _ = new DbClient();
     }).toThrow();
+
     setup();
   });
 });

--- a/packages/db-client/tests/collection.test.ts
+++ b/packages/db-client/tests/collection.test.ts
@@ -3,7 +3,8 @@ import type { MongoDBItem, SortQuery } from "@esp-group-one/types";
 import { describe, expect, test } from "@jest/globals";
 import { CollectionWrap } from "../src/collection.js";
 import { toMongo } from "../src/types.js";
-import { getRawClient, getRawDb, insertMany, setup } from "./helpers/utils.js";
+import { getRawClient, getRawDb, insertMany } from "./helpers/utils.js";
+import { setup } from "./helpers/setup.js";
 
 interface TestObj extends MongoDBItem {
   name: string;

--- a/packages/db-client/tests/helpers/setup.ts
+++ b/packages/db-client/tests/helpers/setup.ts
@@ -1,0 +1,26 @@
+declare global {
+  /**
+   * The URI of the test MongoDB server.
+   */
+  let __MONGO_URI__: string;
+
+  /**
+   * The name of the database you should connect to.
+   */
+  let __MONGO_DB_NAME__: string;
+}
+
+export function setup() {
+  process.env.DB_CONN_STRING = getMongoURL();
+  process.env.DB_NAME = getMongoDBName();
+}
+
+export function getMongoURL(): string {
+  // eslint-disable-next-line no-undef -- it is
+  return __MONGO_URI__;
+}
+
+export function getMongoDBName(): string {
+  // eslint-disable-next-line no-undef -- it is
+  return __MONGO_DB_NAME__;
+}

--- a/packages/db-client/tests/helpers/utils.ts
+++ b/packages/db-client/tests/helpers/utils.ts
@@ -2,23 +2,7 @@ import type { Collection, Db, OptionalId } from "mongodb";
 import { MongoClient } from "mongodb";
 import { ObjectId } from "@esp-group-one/types";
 import { toMongo } from "../../src/types.js";
-
-declare global {
-  /**
-   * The URI of the test MongoDB server.
-   */
-  let __MONGO_URI__: string;
-
-  /**
-   * The name of the database you should connect to.
-   */
-  let __MONGO_DB_NAME__: string;
-}
-
-export function setup() {
-  process.env.DB_CONN_STRING = getMongoURL();
-  process.env.DB_NAME = getMongoDBName();
-}
+import { getMongoURL, getMongoDBName } from "./setup.js";
 
 export async function getRawClient(): Promise<MongoClient> {
   return MongoClient.connect(getMongoURL());
@@ -26,16 +10,6 @@ export async function getRawClient(): Promise<MongoClient> {
 
 export function getRawDb(client: MongoClient): Db {
   return client.db(getMongoDBName());
-}
-
-export function getMongoURL(): string {
-  // eslint-disable-next-line no-undef -- it is
-  return __MONGO_URI__;
-}
-
-export function getMongoDBName(): string {
-  // eslint-disable-next-line no-undef -- it is
-  return __MONGO_DB_NAME__;
 }
 
 export async function insertMany<T>(

--- a/packages/db-client/tests/types.test.ts
+++ b/packages/db-client/tests/types.test.ts
@@ -2,12 +2,12 @@ import { type Document, type Filter, ObjectId } from "mongodb";
 import {
   ObjectId as FakeObjectId,
   type MongoDBItem,
-  tests,
+  helpers,
 } from "@esp-group-one/types";
 import { describe, expect, test } from "@jest/globals";
 import { toInternal, toMongo } from "../src/types.js";
 
-const { IDS } = tests;
+const { IDS } = helpers;
 
 describe("Convert to MongoDB", () => {
   test("Single type", () => {

--- a/packages/mongodb-testing/index.mjs
+++ b/packages/mongodb-testing/index.mjs
@@ -26,11 +26,8 @@ export default class MongoEnvironment extends TestEnvironment {
   async teardown() {
     // Stop the database.
     try {
-      console.log("Stopping");
       await MONGO.stop();
-      console.log("Stopped");
     } catch (e) {
-      console.log("Error");
       console.warn(e);
     }
     await super.teardown();

--- a/packages/mongodb-testing/index.mjs
+++ b/packages/mongodb-testing/index.mjs
@@ -26,8 +26,11 @@ export default class MongoEnvironment extends TestEnvironment {
   async teardown() {
     // Stop the database.
     try {
+      console.log("Stopping");
       await MONGO.stop();
+      console.log("Stopped");
     } catch (e) {
+      console.log("Error");
       console.warn(e);
     }
     await super.teardown();

--- a/packages/test-env/index.mjs
+++ b/packages/test-env/index.mjs
@@ -1,0 +1,239 @@
+// Names given by ChatGPT
+
+import moment from "moment";
+import { DbClient } from "@esp-group-one/db-client";
+import {
+  addLeague,
+  addMatch,
+  addUser,
+  resetCollections,
+} from "../test-helpers/build/src/db.js";
+import { MatchStatus, Sport, helpers as types } from "@esp-group-one/types";
+
+/* CONFIG OPTIONS */
+const db = new DbClient();
+const AUTH0ID = "github|123456"; // TODO: Put your auth 0 token here
+
+await resetCollections(db);
+
+const profilePicture = types.PICTURES[0];
+
+/* LEAGUES */
+const publicLeagues = await Promise.all(
+  [
+    "ThunderStrike Racket League",
+    "VelocityNet Smash Circuit",
+    "RogueSpin Championship Series",
+    "EclipseRacket Pro Tour",
+    "VortexThrash Open",
+    "HavocStrike Racket Premier League",
+    "QuantumQuell Racket Masters",
+  ].map((name) => addLeague(db, { name, ownerIds: [], private: false })),
+);
+
+const privateLeagues = await Promise.all(
+  [
+    "NebulaBlitz Grand Slam",
+    "ApexFury Racket Challenge",
+    "DynamoClash Elite Circuit",
+  ].map((name) => addLeague(db, { name, ownerIds: [], private: true })),
+);
+
+/* YOU THE USER */
+
+const me = await addUser(db, AUTH0ID, {
+  name: "Riley Morgan",
+  leagues: getRandomLeagues(),
+  profilePicture,
+});
+
+await setLeagueOwner(publicLeagues[0], me);
+await setLeagueOwner(privateLeagues[0], me);
+
+/* USERS */
+
+const otherUsers = await Promise.all(
+  [
+    "Jordan Taylor",
+    "Avery Cameron",
+    "Casey Quinn",
+    "Taylor Reed",
+    "Morgan Blake",
+    "Jamie Ellis",
+    "Alex Taylor",
+    "Jordan Avery",
+    "Casey Morgan",
+  ].map((name) => {
+    return addUser(db, `github|${100000 + randomInt(900000)}`, {
+      name,
+      leagues: getRandomLeagues(),
+    });
+  }),
+);
+
+await Promise.all(
+  publicLeagues
+    .slice(1)
+    .map((league, i) => setLeagueOwner(league, otherUsers[i])),
+);
+await Promise.all(
+  privateLeagues
+    .slice(1)
+    .map((league, i) => setLeagueOwner(league, otherUsers[i])),
+);
+
+/* MATCHES */
+
+const myMatches = [
+  await match(db, me, otherUsers[0], MatchStatus.Complete),
+  await match(db, otherUsers[1], me, MatchStatus.Complete),
+
+  await match(db, me, otherUsers[1], MatchStatus.Accepted),
+  await match(db, otherUsers[2], me, MatchStatus.Accepted),
+  await match(db, otherUsers[3], me, MatchStatus.Accepted),
+
+  await match(db, me, otherUsers[2], MatchStatus.Request),
+  await match(db, otherUsers[2], me, MatchStatus.Request),
+  await match(db, otherUsers[2], me, MatchStatus.Request),
+  await match(db, otherUsers[3], me, MatchStatus.Request),
+];
+
+console.log(myMatches);
+
+const allUsers = [me, ...otherUsers];
+
+const matches = [];
+
+for (let i = 0; i < allUsers.length; i++) {
+  for (let j = 0; j < 10; j++) {
+    const r = randomInt(allUsers.length);
+    if (r === i) continue;
+    const states = [
+      MatchStatus.Request,
+      MatchStatus.Accepted,
+      MatchStatus.Complete,
+    ];
+    let status = choose(states);
+
+    matches.push(match(db, allUsers[i], allUsers[r], status));
+  }
+}
+
+await Promise.all(matches);
+
+process.exit(0);
+
+/**
+ * @returns {import("@esp-group-one/types").ObjectId[]}
+ */
+function getRandomLeagues() {
+  const leagues = [];
+  const map = [
+    [publicLeagues, 4],
+    [privateLeagues, 2],
+  ];
+
+  for (const [from, num] of map) {
+    for (let i = 0; i < num; i++) {
+      leagues.push(choose(from)._id);
+    }
+  }
+
+  return leagues;
+}
+
+/**
+ * @param {import("@esp-group-one/types").League} league
+ * @param {import("@esp-group-one/types").User} user
+ */
+async function setLeagueOwner(league, user) {
+  const leagues = await db.leagues();
+  leagues.edit(league._id, { $push: { ownerIds: user._id } });
+
+  const users = await db.users();
+  users.edit(user._id, { $push: { leagues: league._id } });
+}
+
+/**
+ * @param {DbClient} db
+ * @param {import("@esp-group-one/types").User} user1
+ * @param {import("@esp-group-one/types").User} user2
+ * @param {MatchStatus} status
+ *
+ * @returns {Promise<import("@esp-group-one/types").Match>}
+ */
+function match(db, user1, user2, status) {
+  const date =
+    status === MatchStatus.Complete
+      ? moment().add(randomInt(10) + 1, "week")
+      : moment().subtract(randomInt(10) + 1, "week");
+
+  const sport = randomSport();
+
+  const possibleMessages = [
+    "Hey, are you free for a match this weekend?",
+    "Let's schedule a game. How about Saturday afternoon?",
+    `Want to play some ${sport} on Friday evening? I'm free after 6 PM.`,
+    "I'm itching for a match! Any availability this week?",
+    "Calling all players! How about a friendly match on Sunday?",
+    `Game on! Are you up for some ${sport} this Saturday?`,
+    "Looking to organize a match. What's your availability?",
+    "Time for a rematch? Let's plan a game this Thursday.",
+    `Up for some ${sport} action this weekend? Let's set a time.`,
+    "Thinking of hitting the courts. Can you play on Tuesday?",
+    "Craving a match. Any chance you're available on Friday?",
+    `Let's squeeze in a quick game of ${sport} this Sunday. Interested?`,
+    "Match time! How about a showdown on Saturday morning?",
+    "Planning a game night. Join me for a match this Thursday?",
+    "Game day approaching! Let's lock in a time for our match.",
+    "Setting up a friendly match this weekend. Are you in?",
+    "Looking to organize a match-up. What day works for you?",
+    "Feeling competitive. Let's schedule a match for Friday night.",
+    "Time to dust off those rackets! Free for a game on Sunday?",
+    `Game plan: ${sport} on Wednesday. Are you available?`,
+    "---------------------------------------------------------------------------------------------------------------------------------------------",
+    "Hey there! I hope this message finds you well and in good spirits. It's been a while since we caught up, and I've been thinking about organizing something exciting that we can both enjoy together. How about we plan a day filled with adrenaline-pumping sports action? I was thinking we could gather a group of friends and head to the local sports facility for a day of friendly competition and fun.",
+  ];
+
+  const messages = [];
+  for (let i = 0; i < randomInt(8); i++) {
+    messages.push({
+      date: moment().subtract(randomInt(100), "minutes").toISOString(),
+      sender: choose([user1, user2])._id,
+      text: choose(possibleMessages),
+    });
+  }
+
+  const obj = {
+    date: date.toISOString(),
+    sport,
+    messages,
+    players: [user1._id, user2._id],
+    status,
+  };
+
+  if (status === MatchStatus.Complete) {
+    obj.usersRated = [choose([user1._id, user2._id])];
+  }
+
+  if (randomInt(2) === 0) {
+    obj.league = choose(user1.leagues);
+    obj.round = randomInt(3);
+  }
+
+  return addMatch(db, obj);
+}
+
+function randomSport() {
+  const sports = [Sport.Tennis, Sport.Badminton, Sport.Squash];
+  return choose(sports);
+}
+
+function choose(array) {
+  const i = randomInt(array.length);
+  return array[i];
+}
+
+function randomInt(max) {
+  return Math.floor(Math.random() * max);
+}

--- a/packages/test-env/package.json
+++ b/packages/test-env/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "@esp-group-one/test-env",
+  "version": "0.0.1",
+  "main": "index.mjs",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "setup": "(run mongo:stop || true) && run mongo:start && run setup:script",
+    "setup:script": "cross-env DB_NAME=esp DB_CONN_STRING=mongodb://localhost:27017 node ./index.mjs",
+    "mongo:setup": "docker volume create esp_mongo_data",
+    "mongo:start": "cross-env-shell docker run -d --rm -p '127.0.0.1:27017:27017' --name esp-mongo-test -v esp_mongo_data:/data/db --mount '\"type=bind,source=$INIT_CWD/../backend/etc/mongod.conf,target=/etc/mongod.conf\"' mongo:latest --config '/etc/mongod.conf'",
+    "mongo:stop": "docker stop esp-mongo-test"
+  },
+  "dependencies": {
+    "@esp-group-one/db-client": "workspace:^",
+    "@esp-group-one/test-helpers": "workspace:^",
+    "@esp-group-one/types": "workspace:^",
+    "cross-env": "^7.0.3",
+    "moment": "^2.30.1"
+  }
+}

--- a/packages/test-helpers/.eslintrc.cjs
+++ b/packages/test-helpers/.eslintrc.cjs
@@ -1,0 +1,14 @@
+const { join } = require("node:path");
+
+/** @type {import("@types/eslint").ESLint.ConfigData} */
+module.exports = {
+  root: true,
+  env: {
+    es2022: true,
+    jest: true,
+  },
+  parserOptions: {
+    project: join(__dirname, "tsconfig.json"),
+  },
+  extends: ["@esp-group-one"],
+};

--- a/packages/test-helpers/package.json
+++ b/packages/test-helpers/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@esp-group-one/types",
+  "name": "@esp-group-one/test-helpers",
   "private": true,
   "version": "0.1.0",
   "type": "module",
@@ -9,20 +9,23 @@
     "build": "tsc",
     "coverage": "jest --coverage",
     "format": "prettier --write '**/*.tsx' '**/*.ts' '**/*.json'",
-    "lint": "eslint src tests --ext ts,tsx --report-unused-disable-directives",
-    "lint:fix": "eslint src tests --ext ts,tsx --report-unused-disable-directives --fix",
+    "lint": "eslint src --ext ts,tsx --report-unused-disable-directives",
+    "lint:fix": "eslint src --ext ts,tsx --report-unused-disable-directives --fix",
     "test": "jest"
   },
   "devDependencies": {
     "@esp-group-one/eslint-config": "workspace:^",
-    "@jest/globals": "^29.7.0",
     "@types/jest": "^29.5.12",
     "@types/node": "^20.10.6",
     "eslint": "^8.56.0",
-    "jest": "^29.7.0",
-    "moment": "^2.30.1",
+    "mongodb": "^6.4.0",
     "prettier": "^3.1.1",
-    "ts-jest": "^29.1.2",
     "typescript": "^5.0.2"
+  },
+  "dependencies": {
+    "@esp-group-one/db-client": "workspace:^",
+    "@esp-group-one/types": "workspace:^",
+    "@jest/globals": "^29.7.0",
+    "moment": "^2.30.1"
   }
 }

--- a/packages/test-helpers/src/db.ts
+++ b/packages/test-helpers/src/db.ts
@@ -1,0 +1,52 @@
+import { DbClient } from "@esp-group-one/db-client";
+import type { League, Match, User } from "@esp-group-one/types";
+import { helpers as types } from "@esp-group-one/types";
+import type { OptionalId } from "mongodb";
+
+export async function addUser(
+  db: DbClient,
+  auth0Id = "github|123456",
+  base: Partial<User> = {},
+): Promise<User> {
+  const user: OptionalId<User> = types.getUser(base);
+  delete user._id;
+  const insert = await (await db.users()).insert(user);
+  const u: User = { ...user, _id: insert[0] };
+
+  await (await db.userMap()).insert({ auth0Id, internalId: u._id });
+
+  return u;
+}
+
+export async function addLeague(
+  db: DbClient,
+  base: Partial<League> = {},
+): Promise<League> {
+  const league: OptionalId<League> = types.getLeague(base);
+  delete league._id;
+  const insert = await (await db.leagues()).insert(league);
+  const l: League = { ...league, _id: insert[0] };
+
+  return l;
+}
+
+export async function addMatch(
+  db: DbClient,
+  base: Partial<Match> = {},
+): Promise<Match> {
+  const match: OptionalId<Match> = types.getMatch(base);
+  delete match._id;
+  const insert = await (await db.matches()).insert(match);
+  const m: Match = { ...match, _id: insert[0] };
+
+  return m;
+}
+
+export async function resetCollections(db: DbClient): Promise<void> {
+  const collections = await (await db.raw()).collections();
+  const promises = [];
+  for (const c of collections) {
+    promises.push(c.deleteMany());
+  }
+  await Promise.all(promises);
+}

--- a/packages/test-helpers/src/db.ts
+++ b/packages/test-helpers/src/db.ts
@@ -1,4 +1,4 @@
-import { DbClient } from "@esp-group-one/db-client";
+import type { DbClient } from "@esp-group-one/db-client";
 import type { League, Match, User } from "@esp-group-one/types";
 import { helpers as types } from "@esp-group-one/types";
 import type { OptionalId } from "mongodb";

--- a/packages/test-helpers/src/index.ts
+++ b/packages/test-helpers/src/index.ts
@@ -1,0 +1,9 @@
+import { helpers as types } from "@esp-group-one/types";
+import { helpers as db } from "@esp-group-one/db-client";
+
+const { IDS, OIDS, getLeague, getMatch, getUser } = types;
+
+export { IDS, OIDS, db, getLeague, getMatch, getUser, types };
+export * from "./db.js";
+export * from "./mock.js";
+export * from "./jest.js";

--- a/packages/test-helpers/src/jest.ts
+++ b/packages/test-helpers/src/jest.ts
@@ -1,0 +1,50 @@
+import { afterAll, beforeAll, beforeEach, expect } from "@jest/globals";
+import type { MongoDBItem } from "@esp-group-one/types";
+import { DbClient, helpers } from "@esp-group-one/db-client";
+import { resetCollections } from "./db.js";
+
+export function idCmp<T extends MongoDBItem>(a: T, b: T): number {
+  return a._id.mongoDbId.localeCompare(b._id.mongoDbId);
+}
+
+/**
+ * Compares an array without taking positions into account
+ */
+export function compareBag<T>(
+  got: T[],
+  expected: T[],
+  cmp?: (a: T, b: T) => number,
+) {
+  expect(got.sort(cmp)).toStrictEqual(expected.sort(cmp));
+}
+
+/**
+ * Allows you to easily setup a DB and have it properly closed once the tests
+ * are over
+ */
+export class TestDb {
+  #db: DbClient | undefined;
+
+  constructor() {
+    beforeAll(() => {
+      helpers.setup();
+      this.#db = new DbClient();
+    });
+
+    beforeEach(async () => {
+      await this.reset();
+    });
+
+    afterAll(async () => {
+      await this.#db?.close();
+    });
+  }
+
+  get(): DbClient {
+    return this.#db as unknown as DbClient;
+  }
+
+  async reset(): Promise<void> {
+    await resetCollections(this.get());
+  }
+}

--- a/packages/test-helpers/src/mock.ts
+++ b/packages/test-helpers/src/mock.ts
@@ -1,0 +1,21 @@
+import type { Moment } from "moment";
+import moment from "moment";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- required by jest
+type MockableFunction = (...args: any[]) => any;
+
+export function asFuncMock<T extends MockableFunction>(
+  mock: T,
+): jest.MockedFunction<T> {
+  return mock as unknown as jest.MockedFunction<T>;
+}
+
+export function stopTime() {
+  const currentTime = moment().toISOString();
+  jest.mock("moment", () => {
+    return (param?: string) =>
+      jest.requireActual<(inp: string) => Moment>("moment")(
+        param ?? currentTime,
+      );
+  });
+}

--- a/packages/test-helpers/tsconfig.json
+++ b/packages/test-helpers/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "declarationMap": true,
+    "incremental": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "module": "NodeNext",
+    "noImplicitAny": true,
+    "declaration": true,
+    "outDir": "build",
+    "target": "es2022",
+    "allowSyntheticDefaultImports": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "resolveJsonModule": true,
+    "esModuleInterop": true
+  },
+  "include": ["src", "tests"]
+}

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -4,4 +4,4 @@ export * from "./league.js";
 export * from "./match.js";
 export * from "./user.js";
 export * from "./utils.js";
-export * as tests from "../tests/utils.js";
+export * as helpers from "../tests/helpers/utils.js";

--- a/packages/types/src/utils.ts
+++ b/packages/types/src/utils.ts
@@ -24,6 +24,10 @@ export class ObjectId {
     if (!this.verify()) throw Error("Input must be a 24 character hex string");
   }
 
+  public equals(o: ObjectId): boolean {
+    return this.toString() === o.toString();
+  }
+
   public toString(): string {
     return this.mongoDbId;
   }
@@ -65,6 +69,10 @@ export class ObjectId {
       Boolean(/^[a-f0-9]+$/.exec(this.mongoDbId))
     );
   }
+}
+
+export function hasId(arr: ObjectId[], id: ObjectId): boolean {
+  return arr.some((i) => i.equals(id));
 }
 
 export interface MongoDBItem {

--- a/packages/types/tests/helpers/utils.ts
+++ b/packages/types/tests/helpers/utils.ts
@@ -1,0 +1,103 @@
+import moment from "moment";
+import type { ID } from "../../src/utils.js";
+import { ObjectId, Sport } from "../../src/utils.js";
+import type { Match, Scores } from "../../src/match.js";
+import { MatchStatus } from "../../src/match.js";
+import { AbilityLevel, type User, type UserIdMap } from "../../src/user.js";
+import type { League } from "../../src/league.js";
+
+export const IDS: ID[] = ["a", "b", "c", "d", "e"].map((x) => x.repeat(24));
+export const OIDS: ObjectId[] = IDS.map((id) => new ObjectId(id));
+
+export const PICTURES = [
+  "UklGRq4EAABXRUJQVlA4IKIEAADwFACdASpQAFAAPo0+l0elI6IhK5jueKARiWwAxJnM/t3WjdS7d+Svs72vvHhOtunzvnoN3mT0AOmMrrDFMz5qgnIjg5X5NU8en1jv+/3J9kBUPMpda97E6afBMZKb2VT+qwcQx8Krz15p3EsgHLRti6oRVNTSF1InHGtuJRkp1YRwpk+44SVG6vs9Cx+FVOeqCWGGW/Us618Ii8vG64RefW22eOaIPjcX974jOP8wgAD+9oEXVAN8nHycfmdeB6pr8BBFeIxz7n7p6gdOJyHMvPLRjiuCBFhYVvi67EonqyeCnMxjLHhdZBZXU79Nw5Tx7NpeHJlbhKPQtV3Sinjvm4HU0Y6Ywsci4rW+j47pMuASolAUx2kuc1EhojTwNlVwWUnBkvyAOfKlei2+oQuDWSK+zxmK4VBpgJIbzSYGMbmXljmyA8pmIMGu7hdPsUEnZf8h638IgkFyJZ+qpIeAI0oBPbExIt9PgGsoMGqQ5XAcw441xcHxeYv4naK77l3KOsun2oG0XnFLB1x+/j/g3ziBpw/U+dEPGRhHN07XARVK+sRqFyncSbiIxQVzzkKwKW8Q7yq5HIhwhUqvIDS7ERiTxZFssSS15c5WYdg/EvFfZ/AyNyfiIRxGf2FTJUmYzLcZaZCphTDQAsofJS0stt9QPbWYRBTt7O9t6O9N+wUSmuIDGJeZ9NyvveMPTJL1ccn85Oyco1uxnayi4aJYyVG9yDrkUd+msRaXI8q/CuenJY5BTJAvpP+B5qqXMSv0ttWHFYP2Po3cLVkmMJ6PTSjVhRvYU2bKdT5nMT73tOfVwz2aqIPVfo3IeW6m2cya7bxdVVW1Y9D7tvDqru8WAwJjmrC4DpgTss2V3AeWbzTWm2mTbRPpHIAoNhLe7IXHlmcJHayXVTvffloAdfYQqjkm9SdpHgiqqfonO81r1IIqliBQls9JgpUA28juiX68SLIOLB+fQXUl9efkUdwbjVZ7Dd18LOH98pD/hKEUpKZi4EkqEumT62v3N2RZF5c59PPaiT9RWmXGYZXIigTqsMjV8nXdQSc8h8WxdU7dH1/4BtqPpiqUzoXYACFTK3xSlyZnPDeZHlykasVQaG/Fu+VH5uLGZfX/c17Ijaw4gm8zqShS1EQqXzeBtB/46bEA9YA7WfsFOB7n2MiBZuqhNzqcQV9nf5yN12K/SJb512v2/BnGQ02s1DBGfSjuuZMcPthIH+/6pXOkKUeUPIZgYWiAVng8tmaMlBl34ciOsALoJ7Kr5jOOdmJw8I8wuEKMx1vUWHWX9PGqVGiXwXO8KygYyVlyCuysp6IBjHlMXrMofyKbJbWvV1l83nKhPm+A0RwN76M97/OVXIyoWovqcY07GYwxnfbXbCF35ysajTGxtTSzViryP31PTfvLSDQT5yl+jtf5jQs8v8GzSZqyq8ArDgTElJRn5hXsD3zZPhWdhxeD2FvkC47Lt3WELRy+n71+Yf8mQ/FFtPt3UBl7vjLQ95Ja6p2eaHd8c99a3ox6d/PaGhgNIoJSYNARn+t15YAK5+hykqyRZf9qyTvXcht5n4ha7gvq7ed7SLuAAAAA",
+];
+
+export function getLeague(obj: Partial<League>): League {
+  const base = {
+    _id: obj._id ?? new ObjectId(IDS[0]),
+    name: obj.name ?? "My custom League",
+    sport: obj.sport ?? Sport.Squash,
+    ownerIds: obj.ownerIds ?? [new ObjectId(IDS[1])],
+  };
+
+  if (obj.private) {
+    return {
+      ...base,
+      private: true,
+      inviteCode: obj.inviteCode ?? "something",
+    };
+  }
+  return {
+    ...base,
+    private: false,
+  };
+}
+
+export function getMatch(obj: Partial<Match>): Match {
+  const players = obj.players ?? [new ObjectId(IDS[0]), new ObjectId(IDS[1])];
+  const base = {
+    _id: obj._id ?? new ObjectId(IDS[0]),
+    date: obj.date ?? moment().toISOString(),
+    messages: obj.messages ?? [],
+    owner: obj.owner ?? players[0],
+    players,
+    sport: obj.sport ?? Sport.Squash,
+  };
+
+  let match: Match;
+
+  if (obj.status === MatchStatus.Complete) {
+    const score: Scores = {};
+    score[players[0].toString()] = 10;
+    score[players[1].toString()] = 5;
+    match = {
+      ...base,
+      status: MatchStatus.Complete,
+      usersRated: obj.usersRated ?? [],
+      score,
+    };
+  } else {
+    match = { ...base, status: obj.status ?? MatchStatus.Accepted };
+  }
+
+  if ("league" in obj || "round" in obj) {
+    return {
+      ...match,
+      league: obj.league ?? new ObjectId(IDS[3]),
+      round: obj.round ?? 1,
+    };
+  }
+
+  return match;
+}
+
+export function getUser(obj: Partial<User>): User {
+  return {
+    _id: obj._id ?? new ObjectId(IDS[0]),
+    name: obj.name ?? "Test bot",
+    description: obj.description ?? "Tester9000",
+    profilePicture: obj.profilePicture ?? PICTURES[0],
+    email: obj.email ?? "test@test.ts",
+    sports: obj.sports ?? [
+      { sport: Sport.Tennis, ability: AbilityLevel.Beginner },
+      { sport: Sport.Squash, ability: AbilityLevel.Advanced },
+    ],
+    leagues: obj.leagues ?? [new ObjectId(IDS[1])],
+    availability: obj.availability ?? [
+      {
+        timeStart: new Date().toLocaleString(),
+        timeEnd: new Date().toLocaleString(),
+      },
+    ],
+    rating: obj.rating ?? { 1: 5, 2: 10, 3: 20, 4: 50, 5: 10 },
+  };
+}
+
+export function getUserIdMap(obj: Partial<UserIdMap>): UserIdMap {
+  return {
+    _id: obj._id ?? new ObjectId(IDS[0]),
+    internalId: obj.internalId ?? new ObjectId(IDS[0]),
+    auth0Id: obj.auth0Id ?? IDS[0],
+  };
+}

--- a/packages/types/tests/league.test.ts
+++ b/packages/types/tests/league.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "@jest/globals";
 import { censorLeague } from "../src/league.js";
 import { ObjectId, Sport } from "../src/utils.js";
-import { IDS, getLeague } from "./utils.js";
+import { IDS, getLeague } from "./helpers/utils.js";
 
 describe("Censor league", () => {
   test("public league", () => {

--- a/packages/types/tests/user.test.ts
+++ b/packages/types/tests/user.test.ts
@@ -6,7 +6,7 @@ import {
   censorUser,
 } from "../src/user.js";
 import { ObjectId, Sport } from "../src/utils.js";
-import { getUser, IDS } from "./utils.js";
+import { getUser, IDS } from "./helpers/utils.js";
 
 test("user", () => {
   const user = getUser({});

--- a/packages/types/tests/utils.test.ts
+++ b/packages/types/tests/utils.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "@jest/globals";
 import { ObjectId } from "../src/utils.js";
-import { IDS } from "./utils.js";
+import { IDS } from "./helpers/utils.js";
 
 describe("Object ID", () => {
   test("from JSON", () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1789,6 +1789,7 @@ __metadata:
   dependencies:
     "@esp-group-one/eslint-config": "workspace:^"
     "@esp-group-one/jest-esm-transformer": "workspace:^"
+    "@esp-group-one/test-helpers": "workspace:^"
     "@esp-group-one/types": "workspace:^"
     "@jest/globals": "npm:^29.7.0"
     "@types/jest": "npm:^29.5.12"
@@ -1811,6 +1812,7 @@ __metadata:
     "@esp-group-one/eslint-config": "workspace:^"
     "@esp-group-one/jest-esm-transformer": "workspace:^"
     "@esp-group-one/mongodb-testing": "workspace:^"
+    "@esp-group-one/test-helpers": "workspace:^"
     "@esp-group-one/types": "workspace:^"
     "@jest/globals": "npm:^29.7.0"
     "@tsoa/runtime": "npm:^6.0.0"
@@ -1988,6 +1990,24 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@esp-group-one/test-helpers@workspace:^, @esp-group-one/test-helpers@workspace:packages/test-helpers":
+  version: 0.0.0-use.local
+  resolution: "@esp-group-one/test-helpers@workspace:packages/test-helpers"
+  dependencies:
+    "@esp-group-one/db-client": "workspace:^"
+    "@esp-group-one/eslint-config": "workspace:^"
+    "@esp-group-one/types": "workspace:^"
+    "@jest/globals": "npm:^29.7.0"
+    "@types/jest": "npm:^29.5.12"
+    "@types/node": "npm:^20.10.6"
+    eslint: "npm:^8.56.0"
+    moment: "npm:^2.30.1"
+    mongodb: "npm:^6.4.0"
+    prettier: "npm:^3.1.1"
+    typescript: "npm:^5.0.2"
+  languageName: unknown
+  linkType: soft
+
 "@esp-group-one/types@workspace:^, @esp-group-one/types@workspace:packages/types":
   version: 0.0.0-use.local
   resolution: "@esp-group-one/types@workspace:packages/types"
@@ -1998,6 +2018,7 @@ __metadata:
     "@types/node": "npm:^20.10.6"
     eslint: "npm:^8.56.0"
     jest: "npm:^29.7.0"
+    moment: "npm:^2.30.1"
     prettier: "npm:^3.1.1"
     ts-jest: "npm:^29.1.2"
     typescript: "npm:^5.0.2"
@@ -4380,6 +4401,13 @@ __metadata:
   version: 6.2.0
   resolution: "bson@npm:6.2.0"
   checksum: 90f447dbafc97cf84cadcb75fa0fe1eecdcb396492ce3d47b1fbf2e6e2ce88bfcf92d62e491e1a70c2fc4a1bf7825d6ce53ba75ed3359c772c41b93ff84db410
+  languageName: node
+  linkType: hard
+
+"bson@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "bson@npm:6.4.0"
+  checksum: 1d64bf23b57c739ca0ae3f86859b264ea1bb1d6ce822a5ad468bcb990758855a3168af821fdb9fcf5df14872e2555299fa426f8a5a39792d16a1b925150c9532
   languageName: node
   linkType: hard
 
@@ -8827,6 +8855,40 @@ __metadata:
     socks:
       optional: true
   checksum: e846c941b739c503b34c02500db56f966fdb8930420db24214d4305ac987415464ebc9eefaf5da1ffb7521844fc733177433b4cc7ba43c423f55eed4f2670cfe
+  languageName: node
+  linkType: hard
+
+"mongodb@npm:^6.4.0":
+  version: 6.4.0
+  resolution: "mongodb@npm:6.4.0"
+  dependencies:
+    "@mongodb-js/saslprep": "npm:^1.1.0"
+    bson: "npm:^6.4.0"
+    mongodb-connection-string-url: "npm:^3.0.0"
+  peerDependencies:
+    "@aws-sdk/credential-providers": ^3.188.0
+    "@mongodb-js/zstd": ^1.1.0
+    gcp-metadata: ^5.2.0
+    kerberos: ^2.0.1
+    mongodb-client-encryption: ">=6.0.0 <7"
+    snappy: ^7.2.2
+    socks: ^2.7.1
+  peerDependenciesMeta:
+    "@aws-sdk/credential-providers":
+      optional: true
+    "@mongodb-js/zstd":
+      optional: true
+    gcp-metadata:
+      optional: true
+    kerberos:
+      optional: true
+    mongodb-client-encryption:
+      optional: true
+    snappy:
+      optional: true
+    socks:
+      optional: true
+  checksum: 420195252dea0c1911e3653cde99179c3035a60d084f640cb22f1eb25ae6a315693e1d8944c5c856d4c29f6a6885d2a3dad9d941cb357c984781a0b76309ff20
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1990,6 +1990,18 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@esp-group-one/test-env@workspace:packages/test-env":
+  version: 0.0.0-use.local
+  resolution: "@esp-group-one/test-env@workspace:packages/test-env"
+  dependencies:
+    "@esp-group-one/db-client": "workspace:^"
+    "@esp-group-one/test-helpers": "workspace:^"
+    "@esp-group-one/types": "workspace:^"
+    cross-env: "npm:^7.0.3"
+    moment: "npm:^2.30.1"
+  languageName: unknown
+  linkType: soft
+
 "@esp-group-one/test-helpers@workspace:^, @esp-group-one/test-helpers@workspace:packages/test-helpers":
   version: 0.0.0-use.local
   resolution: "@esp-group-one/test-helpers@workspace:packages/test-helpers"


### PR DESCRIPTION
### Summary

- Refactors testing logic into a new package `test-helpers` and makes backend tests significantly easier to write.
- Add package with a script in it which we can run to create a basic database setup

### Testing

Unit tests really (test-helpers is skipped due to the fact that it is specifically written for tests and so will be heavily used in the tests themselves)