### PR TITLE
Use URL parameters over query strings.

### DIFF
--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -54,7 +54,7 @@ export function App() {
     <API.Provider value={ok.client}>
       <Routes>
         <Route index element={<UpcomingMatch />} />
-        <Route path="/profile" element={<ProfilePage />} />
+        <Route path="/profile/:id" element={<ProfilePage />} />
         <Route path="/me" element={<YourProfile />} />
         <Route path="/me/availability" element={<SetAvailability />} />
         <Route path="/me/edit" element={<EditUser />} />

--- a/packages/frontend/src/app.tsx
+++ b/packages/frontend/src/app.tsx
@@ -61,7 +61,7 @@ export function App() {
         <Route path="/me/sports/edit" element={<EditSports />} />
         <Route path="/match/new" element={<NewMatchPage />} />
         <Route path="/league/:id" element={<SingleLeaguePage />} />
-        <Route path="/match" element={<SingleMatchPage />} />
+        <Route path="/match/:id" element={<SingleMatchPage />} />
         <Route path="/match/complete" element={<CompleteMatchForm />} />
         <Route path="/match/proposals" element={<MatchProposal />} />
         <Route path="/league/new" element={<NewLeaguePage />} />

--- a/packages/frontend/src/components/card/match.tsx
+++ b/packages/frontend/src/components/card/match.tsx
@@ -28,7 +28,7 @@ export function MatchCard({
 
   return (
     <Link
-      href={`/match?id=${matchId.toString()}`}
+      href={`/match/${matchId.toString()}`}
       className={twMerge(
         "rounded-lg border w-full border-gray-300 p-2 flex items-center bg-p-grey-200",
         className,

--- a/packages/frontend/src/components/rec_profile.tsx
+++ b/packages/frontend/src/components/rec_profile.tsx
@@ -27,7 +27,7 @@ export function RecProfile({ user, availability, sport, proposeMatch }: Info) {
 
   return (
     <div className="h-fit max-h-fit mt-2 mb-2 snap-start">
-      <Link href={`/profile?id=${user._id.toString()}`}>
+      <Link href={`/profile/${user._id.toString()}`}>
         <div className="overflow-clip max-h-fit rounded-t-lg">
           <ProfilePic
             image={makeImgSrc(user.profilePicture)}

--- a/packages/frontend/src/pages/league/new.tsx
+++ b/packages/frontend/src/pages/league/new.tsx
@@ -32,7 +32,7 @@ export function NewLeaguePage() {
     };
 
     const res = await api.league().create(formData);
-    viewNav(`/league?id=${res._id.toString()}`);
+    viewNav(`/league/${res._id.toString()}`);
   };
 
   return (

--- a/packages/frontend/src/pages/league/single.tsx
+++ b/packages/frontend/src/pages/league/single.tsx
@@ -103,7 +103,7 @@ export function SingleLeaguePage() {
   const [isMember, setIsMember] = useState(false);
 
   if (id === undefined) {
-    redirect("/me/leagues");
+    redirect("/leagues");
     return <></>;
   }
 

--- a/packages/frontend/src/pages/match/complete.tsx
+++ b/packages/frontend/src/pages/match/complete.tsx
@@ -59,7 +59,7 @@ export function CompleteMatchForm() {
   return (
     <Form onSubmit={onSubmit}>
       <Form.Header>
-        <Header.Back defaultLink={`/match?id=${ok.match._id.toString()}`} />
+        <Header.Back defaultLink={`/match/${ok.match._id.toString()}`} />
         Complete your match!
       </Form.Header>
       <Form.Body>

--- a/packages/frontend/src/pages/match/index.tsx
+++ b/packages/frontend/src/pages/match/index.tsx
@@ -2,7 +2,6 @@ import type { FormEventHandler, ReactNode } from "react";
 import { createRef, useCallback, useContext, useEffect, useState } from "react";
 import type {
   CensoredUser,
-  ID,
   Match,
   StarCount,
   User,
@@ -16,7 +15,7 @@ import {
   faUser,
 } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import moment from "moment";
 import { twMerge } from "tailwind-merge";
 import { useViewNav } from "../../state/nav";
@@ -33,8 +32,7 @@ import { useAsync } from "../../lib/async";
 
 export function SingleMatchPage(): ReactNode {
   const api = useContext(API);
-  const [searchParams] = useSearchParams();
-  const id: ID | null = searchParams.get("id");
+  const { id } = useParams();
 
   const [message, setMessage] = useState("");
   const [myError, setError] = useState("");

--- a/packages/frontend/src/pages/profile.tsx
+++ b/packages/frontend/src/pages/profile.tsx
@@ -47,7 +47,7 @@ export function ProfilePage() {
         return (
           <Link
             className="w-full"
-            href={`/match?id=${m._id.toString()}`}
+            href={`/match/${m._id.toString()}`}
             key={m._id.toString()}
           >
             <div className="w-full mt-2 rounded-lg bg-p-grey-200 flex p-3 place-items-center">

--- a/packages/frontend/src/pages/profile.tsx
+++ b/packages/frontend/src/pages/profile.tsx
@@ -1,10 +1,9 @@
-import type { ID } from "@esp-group-one/types";
 import {
   ObjectId,
   calculateAverageRating,
   makeImgSrc,
 } from "@esp-group-one/types";
-import { useSearchParams } from "react-router-dom";
+import { useParams } from "react-router-dom";
 import type { ReactNode } from "react";
 import { useCallback, useContext } from "react";
 import moment from "moment";
@@ -26,11 +25,10 @@ export function ProfilePage() {
   const api = useContext(API);
   const viewNav = useViewNav();
 
-  const [searchParams] = useSearchParams();
-  const id: ID | null = searchParams.get("id");
+  const { id } = useParams();
 
   const { loading, error, ok } = useAsync(async () => {
-    if (!id) throw new Error("not even close");
+    if (!id) throw new Error("No user id provided.");
     const objId = new ObjectId(id);
 
     const user = api.user().getId(objId);
@@ -49,7 +47,7 @@ export function ProfilePage() {
         return (
           <Link
             className="w-full"
-            href={`match?id=${m._id.toString()}`}
+            href={`/match?id=${m._id.toString()}`}
             key={m._id.toString()}
           >
             <div className="w-full mt-2 rounded-lg bg-p-grey-200 flex p-3 place-items-center">

--- a/packages/frontend/src/pages/suggested_people.tsx
+++ b/packages/frontend/src/pages/suggested_people.tsx
@@ -64,7 +64,7 @@ export function SuggestedPeople() {
           searchRes.map((u) => (
             <Link
               key={u._id.toString()}
-              href={`/profile?id=${u._id.toString()}`}
+              href={`/profile/${u._id.toString()}`}
               className="rounded-lg border w-full border-gray-300 p-2 flex items-center bg-p-grey-200 mt-2"
             >
               <div className="mr-4">

--- a/packages/frontend/tests/pages/league/single.test.tsx
+++ b/packages/frontend/tests/pages/league/single.test.tsx
@@ -36,7 +36,7 @@ describe("Routing failures", () => {
     await act(() => Promise.resolve());
 
     expect(comp.container).toBeEmptyDOMElement();
-    expect(Routing.redirect).toHaveBeenCalledWith("/me/leagues");
+    expect(Routing.redirect).toHaveBeenCalledWith("/leagues");
   });
 
   test("Invalid id", () => {


### PR DESCRIPTION
Blocked on #107.
Will fix #106.

Replaces many instances of query strings (but not all of them!), where a URL parameter would be more ideomatic to use (like IDs for resources).

The exception to this is where parameters are given to pages, such as `.../new?id={}` (`id` counts a parameter to the page, so I've kept it.).