### PR TITLE
Add testing for rounds api endpoint

### DIFF
--- a/packages/api-client/tests/sub/league.test.ts
+++ b/packages/api-client/tests/sub/league.test.ts
@@ -86,3 +86,17 @@ describe("nextRound", () => {
 
   runErrorTests(endpoint, () => api.nextRound(id));
 });
+
+describe("rounds", () => {
+  const id = OIDS[0];
+  const endpoint = `league/${IDS[0]}/rounds`;
+
+  test("normal", async () => {
+    fetchMockEndpointOnce(endpoint, newAPISuccess([10, 5]), { query: {} });
+
+    await expect(api.rounds(id)).resolves.toStrictEqual([10, 5]);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  runErrorTests(endpoint, () => api.rounds(id));
+});

--- a/packages/backend/src/league/league_controller.ts
+++ b/packages/backend/src/league/league_controller.ts
@@ -84,13 +84,13 @@ export class LeaguesController extends ControllerWrap<League> {
   public async getLeagueRounds(
     @Path() leagueId: ID,
     @Request() req: express.Request,
-  ): Promise<WithError<{ rounds: string[] }>> {
+  ): Promise<WithError<{ rounds: number[] }>> {
     const id = new ObjectId(leagueId);
 
     return this.withUser(req, async (currUser) => {
       const res = await this.get(id);
       if (res.success) {
-        if (res.data.private && !currUser.leagues.includes(id)) {
+        if (res.data.private && !hasId(currUser.leagues, id)) {
           // Don't want to give away the league exists if user does not have
           // access
           return this.notFound();
@@ -98,7 +98,7 @@ export class LeaguesController extends ControllerWrap<League> {
         const matches = (await this.getDb().matches()).raw();
         const rounds = (await matches.distinct("round", {
           league: new MongoId(id.mongoDbId),
-        })) as string[];
+        })) as number[];
         return newAPISuccess({ rounds });
       }
       return res;


### PR DESCRIPTION
### Summary

This was added after we brought the testing to 100% so now needs to be added again :cry: 

Also does have a fix for the `includes` never actually returning true (`hasId` should be used instead for `ObjectId`s)

### Testing

100% baby